### PR TITLE
fix: correct release version to v1.1.0 for MSA/gMSA/dMSA support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "contoso",
         "coveragexml",
         "csdef",
+        "Dacl",
         "dbmdl",
         "dbproj",
         "dedup",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-06-30
+## [1.1.0] - 2026-06-30
 
 ### Added
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unit test suites for MSA, gMSA, and dMSA ACL operations and updated prerequisite/manifest tests
 - Added integration tests for MSA deploy and audit workflows
 
-## [2.0.0] - 2026-02-27
+## [1.0.0] - 2026-02-27
 
 ### Added
 
@@ -138,18 +138,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example functions that were never implemented
 - Confusing documentation references
 - Outdated cmdlet references in CI/CD pipelines
-
-## [1.0.0] - Initial Release
-
-### Added
-- Basic Active Directory Tier Model framework
-- Organizational Unit management
-- Security Group operations
-- User account management
-- Group Policy Object support
-- Configuration-driven deployment
-- JSON schema validation
-- Pester test framework
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ cd ActiveDirectoryTierModel
 
 ---
 
-**Version**: 1.0.0 | **License**: MIT | **Status**: ✅ Production Ready
+**Version**: 1.1.0 | **License**: MIT | **Status**: ✅ Production Ready
 
 ## 🚀 Releasing
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,24 +13,25 @@
 - Not a substitute for a full security architecture review
 
 ### What version of the Tier Model is this?
-- Current release is **v2.0.0** (released February 27, 2026)
+- Current release is **v1.1.0** (released June 30, 2026)
+- The initial automated release was **v1.0.0** (released February 27, 2026)
 - See the `CHANGELOG.md` file in the repository root for full release history
-- Note that v2.0.0 is a major release with breaking changes from v1.x
+- v1.1.0 is a **minor, backward-compatible** feature release (adds MSA/gMSA/dMSA ACL support); `2.x` is reserved for future breaking changes
 
 ---
 
 ## Upgrading from a Previous Version
 
 ### I deployed an earlier version of the Tier Model. What do I need to know before upgrading?
-- v2.0.0 is a **major release** — review the full CHANGELOG before proceeding
+- This automated module was first released as **v1.0.0** — review the full CHANGELOG before proceeding
 - The deployment script (`Deploy-TierModel.ps1`) is idempotent; existing objects in AD will be skipped, not overwritten
-- New components added in v2.0.0 (e.g., structured logging, drift detection, ADMX management) will be created fresh
+- New components added in v1.0.0 (e.g., structured logging, drift detection, ADMX management) will be created fresh
 - Back up your Active Directory (System State or AD-specific backup) before running any upgrade
 
-### What changed between v1.x and v2.0.0?
+### What changed compared to a legacy, manually-maintained Tier Model?
 - `Deploy-TierModel.ps1` was fully rewritten with component-specific switches (`-OuOnly`, `-GroupOnly`, `-GposOnly`, etc.)
-- `Audit-TierModel.ps1` is a **new script** — it did not exist in v1.x
-- Structured logging with correlation IDs and security redaction is new in v2.0.0
+- `Audit-TierModel.ps1` is a **new script** — it did not exist in legacy manual deployments
+- Structured logging with correlation IDs and security redaction is new in v1.0.0
 - GPO deployment modes expanded to three options: `create`, `createAndImport`, `createImportAndConfigure`
 - ADMX hash verification added for template integrity
 - A **Microsoft Sentinel monitoring pack** has been built against the new structure, enabling day-one SOC monitoring of your Tier Model immediately after deployment
@@ -42,7 +43,7 @@
 - Exceptions and edge cases to be noted here
 
 ### Do I need to re-import my ADMX templates?
-- If you previously imported ADMX templates manually, they may not match the v2.0.0 hash manifest
+- If you previously imported ADMX templates manually, they may not match the v1.0.0 hash manifest
 - Use the drift detection audit (`Audit-TierModel.ps1`) to identify hash mismatches before re-importing
 - Re-import can be triggered with `-AdmxOnly` or as part of `-FullDeployment`
 
@@ -82,9 +83,9 @@ The high-level migration path is:
 ### My previous deployment used a different OU structure. What happens?
 - The Tier Model will create any OUs defined in `tiermodel-ous.json` that do not already exist
 - OUs that exist in your environment but are **not** in the config will be left untouched
-- If your existing OU paths differ from the v2.0.0 defaults, update `tiermodel-ous.json` accordingly before deploying
+- If your existing OU paths differ from the v1.0.0 defaults, update `tiermodel-ous.json` accordingly before deploying
 
-### Can I roll back to v1.x if something goes wrong?
+### Can I roll back to a previous manual configuration if something goes wrong?
 - The Tier Model does not provide an automated rollback mechanism
 - Because all objects created by the Tier Model are **new objects not in production use**, the recommended remediation for any deployment failure is to **delete the affected object(s) and redeploy** using the appropriate component-specific switch
   - Example: if a GPO fails to import, delete the GPO in GPMC or via PowerShell, resolve the underlying issue, then re-run `Deploy-TierModel.ps1 -GposOnly` until all GPOs import successfully

--- a/modules/TierModel/TierModel.psd1
+++ b/modules/TierModel/TierModel.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'TierModel.psm1'
-    ModuleVersion = '2.1.0'
+    ModuleVersion = '1.1.0'
     GUID = 'b6a7c9f8-5e5d-4c7a-9b9e-2e2e9a4f6d10'
     Author = 'TierModel Team'
     CompanyName = 'Enterprise AD'
@@ -74,7 +74,7 @@
     PrivateData = @{ 
         PSData = @{
             Tags = @('ActiveDirectory', 'TierModel', 'Security', 'GPO', 'ADMX', 'Deployment', 'Audit')
-            ReleaseNotes = '2.1.0: Added Managed Service Account (MSA/gMSA/dMSA) ACL deployment and audit cmdlets. 2.0.0: Segmented JSON config, fail-fast validation, correlation ID logging, ADMX import'
+            ReleaseNotes = '1.1.0: Added Managed Service Account (MSA/gMSA/dMSA) ACL deployment and audit cmdlets. 1.0.0: Segmented JSON config, fail-fast validation, correlation ID logging, ADMX import'
         }
     }
 }

--- a/modules/TierModel/public/Test-TierModelDmsaAcl.ps1
+++ b/modules/TierModel/public/Test-TierModelDmsaAcl.ps1
@@ -184,13 +184,13 @@ function Test-TierModelDmsaAcl {
             
             # Step 2: Check if identity/group exists
             try {
-                $groupObject = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                $null = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
                 if (-not $Silent) {
                     Write-Host "    ✅ Identity '$identityReference' exists (Group)" -ForegroundColor Green
                 }
             } catch {
                 try {
-                    $userObject = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                    $null = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
                     if (-not $Silent) {
                         Write-Host "    ✅ Identity '$identityReference' exists (User)" -ForegroundColor Green
                     }

--- a/modules/TierModel/public/Test-TierModelGmsaAcl.ps1
+++ b/modules/TierModel/public/Test-TierModelGmsaAcl.ps1
@@ -174,13 +174,13 @@ function Test-TierModelGmsaAcl {
             
             # Step 2: Check if identity/group exists
             try {
-                $groupObject = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                $null = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
                 if (-not $Silent) {
                     Write-Host "    ✅ Identity '$identityReference' exists (Group)" -ForegroundColor Green
                 }
             } catch {
                 try {
-                    $userObject = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                    $null = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
                     if (-not $Silent) {
                         Write-Host "    ✅ Identity '$identityReference' exists (User)" -ForegroundColor Green
                     }

--- a/modules/TierModel/public/Test-TierModelMsaAcl.ps1
+++ b/modules/TierModel/public/Test-TierModelMsaAcl.ps1
@@ -174,13 +174,13 @@ function Test-TierModelMsaAcl {
             
             # Step 2: Check if identity/group exists
             try {
-                $groupObject = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                $null = Get-ADGroup -Identity $identityReference -Server $DomainController -ErrorAction Stop
                 if (-not $Silent) {
                     Write-Host "    ✅ Identity '$identityReference' exists (Group)" -ForegroundColor Green
                 }
             } catch {
                 try {
-                    $userObject = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
+                    $null = Get-ADUser -Identity $identityReference -Server $DomainController -ErrorAction Stop
                     if (-not $Silent) {
                         Write-Host "    ✅ Identity '$identityReference' exists (User)" -ForegroundColor Green
                     }

--- a/tests/Integration.Module.Tests.ps1
+++ b/tests/Integration.Module.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'TierModel Module Integration Tests' -Tag 'Integration', 'Module' {
         }
         
         It 'Module version is correct' {
-            $script:LoadedModule.Version.ToString() | Should -Be '2.1.0'
+            $script:LoadedModule.Version.ToString() | Should -Be '1.1.0'
         }
         
         It 'Module loads all public function files' {

--- a/tests/Unit.ModuleManifest.Tests.ps1
+++ b/tests/Unit.ModuleManifest.Tests.ps1
@@ -38,8 +38,8 @@ Describe 'TierModel Module Manifest' -Tag 'Unit', 'Manifest' {
             $script:Manifest.ModuleVersion | Should -Match '^\d+\.\d+\.\d+$'
         }
         
-        It 'Has current version 2.1.0' {
-            $script:Manifest.ModuleVersion | Should -Be '2.1.0'
+        It 'Has current version 1.1.0' {
+            $script:Manifest.ModuleVersion | Should -Be '1.1.0'
         }
         
         It 'Has valid GUID' {
@@ -393,7 +393,7 @@ Describe 'TierModel Module Manifest' -Tag 'Unit', 'Manifest' {
         }
         
         It 'Release notes mention current version' {
-            $script:Manifest.PrivateData.PSData.ReleaseNotes | Should -Match '2\.0\.0'
+            $script:Manifest.PrivateData.PSData.ReleaseNotes | Should -Match '1\.1\.0'
         }
     }
 }


### PR DESCRIPTION
## Summary
Corrects the release version for the MSA/gMSA/dMSA ACL support. It was mistakenly published as **v2.1.0**; because it is a backward-compatible feature it should be a **MINOR** bump over the initial **v1.0.0** release. `2.x` is reserved for breaking changes. This renumbers the whole history to the 1.x line and pulls in the PSScriptAnalyzer fixes.

> Note: the erroneous `v2.1.0` GitHub Release/tag is being deleted separately by the maintainer.

## Changes
- **Manifest** (`TierModel.psd1`): `ModuleVersion` 2.1.0 → **1.1.0**; `ReleaseNotes` renumbered (2.1.0→1.1.0, 2.0.0→1.0.0)
- **CHANGELOG**: `[2.1.0]`→`[1.1.0]`, `[2.0.0]`→`[1.0.0]`; removed the redundant `[1.0.0] - Initial Release` stub (subsumed by the renumbered initial entry)
- **README**: version badge 1.0.0 → **1.1.0**
- **docs/faq.md**: current release now v1.1.0; corrected the upgrade/migration narrative that referenced a non-existent v2.0.0
- **Tests**: manifest/module version assertions → 1.1.0
- **PSScriptAnalyzer**: fixed `PSUseDeclaredVarsMoreThanAssignments` (6 alerts) in the MSA/gMSA/dMSA ACL cmdlets by assigning existence checks to `$null`

## Not changed (intentional)
- `2.0.0` in `Unit.AdmxImport`/`Unit.Prerequisites` tests and `docs/admx-management.md` are **JSON schema** versions, not the module version
- `specs/` and `.squad/` retain their historical records

## Testing
- Version-affected + MSA/gMSA/dMSA ACL suites: **289/289 pass**
- Full suite: **1290 passed, 2 failed** — the 2 failures are **pre-existing** full-suite ordering flakes in `Import-TierModelGpo` (identical on the untouched baseline; both pass in isolation)
