### PR TITLE
ci: pin Pester to exact 5.7.1 to fix daily CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         Set-PSRepository PSGallery -InstallationPolicy Trusted
         Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
-        Install-Module -Name Pester -Force -Scope CurrentUser
+        Install-Module -Name Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1
         Write-Host "Installed PowerShell modules successfully"
         
     - name: Run ScriptAnalyzer
@@ -90,7 +90,7 @@ jobs:
       shell: pwsh
       run: |
         Set-PSRepository PSGallery -InstallationPolicy Trusted
-        Install-Module -Name Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+        Install-Module -Name Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1
         Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
         Write-Host "Pester version: $((Get-Module Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1).Version)"
         


### PR DESCRIPTION
## Summary

The daily scheduled **TierModel CI** started failing on **Jul 8** and **Jul 9** with **44 failed Pester tests** — despite **no repository change**. Root cause: an unpinned test dependency auto-upgraded.

## Root cause

The workflow installed Pester with an unbounded floor:

```powershell
Install-Module -Name Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
```

`-MinimumVersion 5.0.0` sets no ceiling, so each run pulls the newest Gallery version. **Pester 6.0.0 was published between the Jul 7 (03:03 UTC) and Jul 8 (03:00 UTC) runs**, so the runner auto-upgraded:

| Date | Pester installed | Result |
|------|------------------|--------|
| Jul 7 (last pass) | **5.8.0** | ✅ 1292 passed |
| Jul 8 / Jul 9 | **6.0.0** | ❌ 44 failed |

Pester 6 ships breaking changes to the **mock engine**: an unmatched `-ParameterFilter` mock now **throws** instead of falling through to the real command. That produced the failures seen in the logs:

- `No mock for command 'New-Object' matched the call... there is no default mock to fall back to`
- `Should -Invoke ... -Times 1` → `Expected 1, but got 0`
- status `Error` returned instead of `Pass`/`Fail` (`Expected length: 4 ... But was: 'Error'`)

## Fix

Pin Pester to **`-RequiredVersion 5.7.1`** in both the `lint` and `test` jobs. This aligns CI with:

- `config/dependencies.json` (`"pester": "5.7.1"`)
- the exact-version check in `Test-TierModelPrerequisites`
- the **no floating/latest** dependency-governance principle in the constitution

It also blocks any accidental Pester 6 run in CI.

## Validation

Ran the full suite locally against **Pester 5.7.1** (pwsh 7.6.3):

```
Total:   1292
Passed:  1292
Failed:  0
Skipped: 0
```

Fixes #15
