### PR TITLE
fix: language-independent AD principal resolution; auto-provision KDS…

### DIFF
--- a/Deploy-TierModel.ps1
+++ b/Deploy-TierModel.ps1
@@ -1030,6 +1030,60 @@ function Invoke-GpoDeployment {
     }
 }
 
+function Invoke-TierModelOptionalPrereqSetup {
+    <#
+    .SYNOPSIS
+    Auto-provisions prerequisites for the optional -Include* features in execution mode.
+
+    .DESCRIPTION
+    - gMSA/dMSA: creates a KDS Root Key on the domain controller if none exists.
+      The key is created with an EffectiveTime backdated by 10 hours so it is
+      usable immediately (no 10-hour replication wait). In multi-DC environments
+      make sure AD replication has converged before creating gMSA/dMSA accounts.
+    - Windows LAPS: extends the AD schema via Update-LapsADSchema if the
+      msLAPS-* attributes are not present. Requires Schema Admins membership.
+    Failures are reported as warnings; the subsequent prerequisites check will
+    then fail with the standard remediation guidance.
+    #>
+    param(
+        [Parameter(Mandatory)] [string]$DomainController,
+        [switch]$NeedsKdsRootKey,
+        [switch]$NeedsWinLapsSchema
+    )
+
+    if ($NeedsKdsRootKey) {
+        try {
+            $kdsKeys = Invoke-Command -ComputerName $DomainController -ScriptBlock { Get-KdsRootKey } -ErrorAction Stop
+            if ($null -eq $kdsKeys -or @($kdsKeys).Count -eq 0) {
+                Write-Host "  No KDS Root Key found - creating one with backdated EffectiveTime (effective immediately)..." -ForegroundColor Yellow
+                Invoke-Command -ComputerName $DomainController -ScriptBlock {
+                    Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10))
+                } -ErrorAction Stop | Out-Null
+                Write-Host "  ✅ KDS Root Key created (EffectiveTime backdated 10 hours)" -ForegroundColor Green
+                Write-Host "     Note: in multi-DC environments, wait for AD replication before creating gMSA/dMSA accounts." -ForegroundColor DarkYellow
+            }
+        } catch {
+            Write-Host "  ⚠️  Could not auto-create KDS Root Key: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+
+    if ($NeedsWinLapsSchema) {
+        try {
+            $rootDSE = Get-ADRootDSE -Server $DomainController -ErrorAction Stop
+            $lapsAttr = Get-ADObject -Filter "lDAPDisplayName -eq 'msLAPS-EncryptedPassword'" -SearchBase $rootDSE.schemaNamingContext -Server $DomainController -ErrorAction SilentlyContinue
+            if (-not $lapsAttr) {
+                Write-Host "  Windows LAPS schema extensions not found - extending AD schema (Update-LapsADSchema)..." -ForegroundColor Yellow
+                Import-Module LAPS -ErrorAction Stop -Verbose:$false
+                Update-LapsADSchema -Confirm:$false -ErrorAction Stop
+                Write-Host "  ✅ Windows LAPS schema extended successfully" -ForegroundColor Green
+            }
+        } catch {
+            Write-Host "  ⚠️  Could not extend Windows LAPS schema: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "     Update-LapsADSchema requires Schema Admins membership and the LAPS PowerShell module." -ForegroundColor DarkYellow
+        }
+    }
+}
+
 function Write-IncludeAclPlanActions {
     param(
         [Parameter(Mandatory)] [object[]]$Actions
@@ -1770,7 +1824,14 @@ if ($FullDeployment) {
         # === OPTIONAL FEATURES: MSA/gMSA/dMSA/WinLaps ACL Delegations ===
         if ($activeIncludeCount -gt 0 -and -not $standardDeployHadErrors) {
             Write-Host "`n=== Optional Features: MSA/gMSA/dMSA/WinLaps ACL Delegations ===" -ForegroundColor Magenta
-            
+
+            # Auto-provision optional prerequisites (KDS Root Key, Windows LAPS schema)
+            if ($ConfirmApply) {
+                Invoke-TierModelOptionalPrereqSetup -DomainController $PreferredDc `
+                    -NeedsKdsRootKey:($IncludeGmsa -or $IncludeDmsa) `
+                    -NeedsWinLapsSchema:$IncludeWinLaps
+            }
+
             # Pass Include switches to prerequisites
             $prereqSplat = @{ PreferredDc = $PreferredDc }
             if ($IncludeMsa) { $prereqSplat['IncludeMsa'] = $true }
@@ -2333,6 +2394,13 @@ if ($activeScopeCount -eq 0 -and $activeIncludeCount -gt 0) {
     $config = Get-TierModelConfig
     Write-Host "TierModel module loaded successfully." -ForegroundColor Green
     
+    # Auto-provision optional prerequisites (KDS Root Key, Windows LAPS schema)
+    if ($ConfirmApply) {
+        Invoke-TierModelOptionalPrereqSetup -DomainController $PreferredDc `
+            -NeedsKdsRootKey:($IncludeGmsa -or $IncludeDmsa) `
+            -NeedsWinLapsSchema:$IncludeWinLaps
+    }
+
     # Run prerequisites with Include switches
     Write-Host "Validating prerequisites..." -ForegroundColor Yellow
     $prereqSplat = @{ PreferredDc = $PreferredDc }

--- a/config/tiermodel-gpos.json
+++ b/config/tiermodel-gpos.json
@@ -776,8 +776,8 @@
               "*S-1-5-32-559__Members",
               "*S-1-5-32-558__Memberof",
               "*S-1-5-32-558__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
               "*S-1-5-32-550__Memberof",
               "*S-1-5-32-550__Members",
               "*S-1-5-32-576__Memberof",
@@ -793,8 +793,8 @@
               "*S-1-5-32-552__Members",
               "*S-1-5-32-582__Memberof",
               "*S-1-5-32-582__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -1323,10 +1323,10 @@
               "*S-1-5-32-552__Members",
               "*S-1-5-32-582__Memberof",
               "*S-1-5-32-582__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -1896,10 +1896,10 @@
               "*S-1-5-32-558__Members",
               "*S-1-5-32-580__Memberof",
               "*S-1-5-32-580__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -2407,10 +2407,10 @@
               "*S-1-5-32-583__Members",
               "*S-1-5-32-585__Memberof",
               "*S-1-5-32-585__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -3003,10 +3003,10 @@
               "*S-1-5-32-583__Members",
               "*S-1-5-32-585__Memberof",
               "*S-1-5-32-585__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -3585,10 +3585,10 @@
               "*S-1-5-32-583__Members",
               "*S-1-5-32-585__Memberof",
               "*S-1-5-32-585__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {
@@ -3785,10 +3785,10 @@
               "*S-1-5-32-558__Members",
               "*S-1-5-32-580__Memberof",
               "*S-1-5-32-580__Members",
-              "Power Users__Memberof",
-              "Power Users__Members",
-              "User Mode Hardware Operators__Memberof",
-              "User Mode Hardware Operators__Members"
+              "*S-1-5-32-547__Memberof",
+              "*S-1-5-32-547__Members",
+              "*S-1-5-32-584__Memberof",
+              "*S-1-5-32-584__Members"
             ],
             "membershipGroups": [
               {

--- a/modules/TierModel/public/Get-TierModelWinLapsAcl.ps1
+++ b/modules/TierModel/public/Get-TierModelWinLapsAcl.ps1
@@ -206,8 +206,27 @@ function Get-TierModelWinLapsAcl {
 
         foreach ($group in $uniqueGroups) {
             try {
-                $escapedName = $group -replace "'", "''"
-                $adGroup = Get-ADGroup -Filter "Name -eq '$escapedName'" -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                $adGroup = $null
+
+                # Well-known groups (e.g. "Domain Admins") first via fixed SID/RID —
+                # their display names are localized in non-English ADs
+                $wellKnownSid = $null
+                try {
+                    $wellKnownSid = Get-WellKnownSid -Principal $group
+                    if (-not $wellKnownSid) {
+                        $wellKnownSid = Get-WellKnownDomainRidSid -Principal $group -DomainController $DomainController
+                    }
+                } catch { $wellKnownSid = $null }
+                if ($wellKnownSid) {
+                    try {
+                        $adGroup = Get-ADGroup -Identity $wellKnownSid -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                    } catch { $adGroup = $null }
+                }
+
+                if (-not $adGroup) {
+                    $escapedName = $group -replace "'", "''"
+                    $adGroup = Get-ADGroup -Filter "Name -eq '$escapedName'" -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                }
                 if ($adGroup) {
                     $groupResolution[$group] = "$netBIOSDomain\$($adGroup.sAMAccountName)"
                 } else {

--- a/modules/TierModel/public/Get-TierModelWinLapsAcl.ps1
+++ b/modules/TierModel/public/Get-TierModelWinLapsAcl.ps1
@@ -218,6 +218,18 @@ function Get-TierModelWinLapsAcl {
                     }
                 } catch { $wellKnownSid = $null }
                 if ($wellKnownSid) {
+                    # Translate the SID locally first — this yields the correct
+                    # domain prefix even for forest-root groups (e.g. Enterprise
+                    # Admins) when running from a child domain
+                    try {
+                        $ntAccount = ([System.Security.Principal.SecurityIdentifier]::new($wellKnownSid)).Translate([System.Security.Principal.NTAccount]).Value
+                        if ($ntAccount) {
+                            $groupResolution[$group] = $ntAccount
+                            continue
+                        }
+                    } catch {
+                        # Translation unavailable — fall back to AD lookup by SID
+                    }
                     try {
                         $adGroup = Get-ADGroup -Identity $wellKnownSid -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
                     } catch { $adGroup = $null }

--- a/modules/TierModel/public/Get-TierModelWinLapsAclFd.ps1
+++ b/modules/TierModel/public/Get-TierModelWinLapsAclFd.ps1
@@ -156,8 +156,27 @@ function Get-TierModelWinLapsAclFd {
         $uniqueGroups = @($allGroupNames | Select-Object -Unique)
         foreach ($group in $uniqueGroups) {
             try {
-                $escapedName = $group -replace "'", "''"
-                $adGroup = Get-ADGroup -Filter "Name -eq '$escapedName'" -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                $adGroup = $null
+
+                # Well-known groups (e.g. "Domain Admins") first via fixed SID/RID —
+                # their display names are localized in non-English ADs
+                $wellKnownSid = $null
+                try {
+                    $wellKnownSid = Get-WellKnownSid -Principal $group
+                    if (-not $wellKnownSid) {
+                        $wellKnownSid = Get-WellKnownDomainRidSid -Principal $group -DomainController $DomainController
+                    }
+                } catch { $wellKnownSid = $null }
+                if ($wellKnownSid) {
+                    try {
+                        $adGroup = Get-ADGroup -Identity $wellKnownSid -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                    } catch { $adGroup = $null }
+                }
+
+                if (-not $adGroup) {
+                    $escapedName = $group -replace "'", "''"
+                    $adGroup = Get-ADGroup -Filter "Name -eq '$escapedName'" -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
+                }
                 if ($adGroup) {
                     $groupResolution[$group] = "$netBIOSDomain\$($adGroup.sAMAccountName)"
                 }

--- a/modules/TierModel/public/Get-TierModelWinLapsAclFd.ps1
+++ b/modules/TierModel/public/Get-TierModelWinLapsAclFd.ps1
@@ -168,6 +168,18 @@ function Get-TierModelWinLapsAclFd {
                     }
                 } catch { $wellKnownSid = $null }
                 if ($wellKnownSid) {
+                    # Translate the SID locally first — this yields the correct
+                    # domain prefix even for forest-root groups (e.g. Enterprise
+                    # Admins) when running from a child domain
+                    try {
+                        $ntAccount = ([System.Security.Principal.SecurityIdentifier]::new($wellKnownSid)).Translate([System.Security.Principal.NTAccount]).Value
+                        if ($ntAccount) {
+                            $groupResolution[$group] = $ntAccount
+                            continue
+                        }
+                    } catch {
+                        # Translation unavailable — fall back to AD lookup by SID
+                    }
                     try {
                         $adGroup = Get-ADGroup -Identity $wellKnownSid -Server $DomainController -Properties sAMAccountName -ErrorAction Stop
                     } catch { $adGroup = $null }

--- a/modules/TierModel/public/New-TierModelGpo.ps1
+++ b/modules/TierModel/public/New-TierModelGpo.ps1
@@ -115,21 +115,26 @@ function New-TierModelGpo {
                                 # Get domain info for building ADSI path
                                 $domain = Get-ADDomain -Server $DomainController
                                 $domainDN = $domain.DistinguishedName
-                                $domainNetbios = $domain.NetBIOSName
-                                
+
                                 # Build ADSI path to GPO container (GPC) in AD
                                 $gpcAdsiPath = "LDAP://CN={$($newGPO.Id)},CN=Policies,CN=System,$domainDN"
                                 $gpc = [ADSI]$gpcAdsiPath
-                                
-                                # Resolve group identity to NTAccount
-                                $ntAccount = New-Object System.Security.Principal.NTAccount("$domainNetbios", $denyGroup)
-                                
+
+                                # Resolve group to SID (language-independent for well-known
+                                # groups like "Domain Controllers", which are localized in
+                                # non-English ADs)
+                                $sidResult = Resolve-TierModelPrincipalSid -Principal $denyGroup -DomainController $DomainController -CorrelationId $CorrelationId
+                                if (-not $sidResult.Success) {
+                                    throw "Could not resolve SID for deny group '$denyGroup': $($sidResult.Error)"
+                                }
+                                $denyIdentity = [System.Security.Principal.SecurityIdentifier]::new($sidResult.Sid)
+
                                 # Apply GPO extended right GUID (documented standard)
                                 $applyGpoGuid = [Guid]"edacfd8f-ffb3-11d1-b41d-00a0c968f939"
-                                
+
                                 # Build a Deny ACE for Apply GPO extended right
                                 $denyAce = New-Object System.DirectoryServices.ActiveDirectoryAccessRule `
-                                    ($ntAccount, "ExtendedRight", "Deny", $applyGpoGuid)
+                                    ($denyIdentity, "ExtendedRight", "Deny", $applyGpoGuid)
                                 
                                 # Add ACE and commit
                                 $acl = $gpc.ObjectSecurity

--- a/modules/TierModel/public/New-TierModelWinLapsAcl.ps1
+++ b/modules/TierModel/public/New-TierModelWinLapsAcl.ps1
@@ -81,6 +81,14 @@ function New-TierModelWinLapsAcl {
                         CorrelationId    = $CorrelationId
                     } | Out-Null
 
+                    # Guard: Read/Reset operations require at least one resolved principal.
+                    # An empty list means group resolution failed during planning (e.g.
+                    # localized AD where a well-known group name could not be resolved).
+                    if ($lapsOp -in @('SetReadPasswordPermission', 'SetResetPasswordPermission') -and
+                        @($action.Data.allowedPrincipals).Count -eq 0) {
+                        throw "No resolvable principals for $lapsOp on '$ouDn'. Verify the readGroup/resetGroup names in tiermodel-winlaps.json exist (well-known groups are resolved via SID; custom groups must exist before the WinLAPS phase)."
+                    }
+
                     $shouldProcessTarget = "OU: $ouDn"
                     $shouldProcessAction = switch ($lapsOp) {
                         'SetComputerSelfPermission'  { "Set-LapsADComputerSelfPermission -DomainController $DomainController" }

--- a/modules/TierModel/public/Resolve-TierModelPrincipalSid.ps1
+++ b/modules/TierModel/public/Resolve-TierModelPrincipalSid.ps1
@@ -429,8 +429,10 @@ function Get-TierModelDomainSid {
     if ($ForestRoot) {
         $forest = Get-ADForest -Server $DomainController -ErrorAction Stop
         if ($forest.RootDomain -and $forest.RootDomain -ne $domain.DNSRoot) {
-            # Child domain: forest-level groups live in the forest root domain
-            $domain = Get-ADDomain -Identity $forest.RootDomain -ErrorAction Stop
+            # Child domain: forest-level groups live in the forest root domain.
+            # Target the root domain by name so the AD module locates a DC of
+            # that domain within the forest we are already talking to.
+            $domain = Get-ADDomain -Identity $forest.RootDomain -Server $forest.RootDomain -ErrorAction Stop
         }
     }
 

--- a/modules/TierModel/public/Resolve-TierModelPrincipalSid.ps1
+++ b/modules/TierModel/public/Resolve-TierModelPrincipalSid.ps1
@@ -145,9 +145,44 @@ function Resolve-TierModelPrincipalSid {
             }
         }
         
+        # Try domain-relative well-known RIDs (language-independent).
+        # Groups like "Domain Admins" have localized names in non-English ADs
+        # (e.g. "Domänen-Admins" in German), but their RID is fixed. Resolving
+        # via <DomainSID>-<RID> works in every AD language and also protects
+        # against spoofed groups that reuse a well-known English name.
+        $ridSid = $null
+        try {
+            $ridSid = Get-WellKnownDomainRidSid -Principal $Principal -DomainController $DomainController
+        }
+        catch {
+            Write-Verbose "Domain RID resolution unavailable for '$Principal': $($_.Exception.Message) (CorrelationId: $CorrelationId)"
+        }
+        if ($ridSid) {
+            Write-Verbose "Resolved well-known domain RID SID for '$Principal': $ridSid (CorrelationId: $CorrelationId)"
+            $result = @{
+                Sid = $ridSid
+                Source = "WellKnownRid"
+                Success = $true
+                Error = $null
+            }
+
+            if ($UseCache) {
+                $script:SidCache[$Principal] = $result
+            }
+
+            return [PSCustomObject]@{
+                Principal = $Principal
+                Sid = $ridSid
+                Source = "WellKnownRid"
+                Cached = $false
+                Success = $true
+                Error = $null
+            }
+        }
+
         # Try AD resolution
         try {
-            $adResult = Resolve-ADPrincipalSid -Principal $Principal -CorrelationId $CorrelationId
+            $adResult = Resolve-ADPrincipalSid -Principal $Principal -DomainController $DomainController -CorrelationId $CorrelationId
             
             if ($adResult.Success) {
                 Write-Verbose "Resolved AD SID for '$Principal': $($adResult.Sid) (CorrelationId: $CorrelationId)"
@@ -261,12 +296,29 @@ function Get-WellKnownSid {
         "BUILTIN\Print Operators" = "S-1-5-32-550"
         "BUILTIN\Backup Operators" = "S-1-5-32-551"
         "BUILTIN\Replicator" = "S-1-5-32-552"
+        "BUILTIN\Pre-Windows 2000 Compatible Access" = "S-1-5-32-554"
+        "BUILTIN\Remote Desktop Users" = "S-1-5-32-555"
         "BUILTIN\Network Configuration Operators" = "S-1-5-32-556"
+        "BUILTIN\Incoming Forest Trust Builders" = "S-1-5-32-557"
         "BUILTIN\Performance Monitor Users" = "S-1-5-32-558"
         "BUILTIN\Performance Log Users" = "S-1-5-32-559"
+        "BUILTIN\Windows Authorization Access Group" = "S-1-5-32-560"
+        "BUILTIN\Terminal Server License Servers" = "S-1-5-32-561"
         "BUILTIN\Distributed COM Users" = "S-1-5-32-562"
         "BUILTIN\IIS_IUSRS" = "S-1-5-32-568"
+        "BUILTIN\Cryptographic Operators" = "S-1-5-32-569"
         "BUILTIN\Event Log Readers" = "S-1-5-32-573"
+        "BUILTIN\Certificate Service DCOM Access" = "S-1-5-32-574"
+        "BUILTIN\RDS Remote Access Servers" = "S-1-5-32-575"
+        "BUILTIN\RDS Endpoint Servers" = "S-1-5-32-576"
+        "BUILTIN\RDS Management Servers" = "S-1-5-32-577"
+        "BUILTIN\Hyper-V Administrators" = "S-1-5-32-578"
+        "BUILTIN\Access Control Assistance Operators" = "S-1-5-32-579"
+        "BUILTIN\Remote Management Users" = "S-1-5-32-580"
+        "BUILTIN\Storage Replica Administrators" = "S-1-5-32-582"
+        "BUILTIN\Device Owners" = "S-1-5-32-583"
+        "BUILTIN\User Mode Hardware Operators" = "S-1-5-32-584"
+        "BUILTIN\OpenSSH Users" = "S-1-5-32-585"
         
         # NT Authority
         "NT AUTHORITY\SYSTEM" = "S-1-5-18"
@@ -293,11 +345,41 @@ function Get-WellKnownSid {
         "Administrators" = "S-1-5-32-544"
         "Users" = "S-1-5-32-545"
         "Guests" = "S-1-5-32-546"
+        "Power Users" = "S-1-5-32-547"
+        "Account Operators" = "S-1-5-32-548"
+        "Server Operators" = "S-1-5-32-549"
+        "Print Operators" = "S-1-5-32-550"
+        "Backup Operators" = "S-1-5-32-551"
+        "Replicator" = "S-1-5-32-552"
+        "Pre-Windows 2000 Compatible Access" = "S-1-5-32-554"
+        "Remote Desktop Users" = "S-1-5-32-555"
+        "Network Configuration Operators" = "S-1-5-32-556"
+        "Incoming Forest Trust Builders" = "S-1-5-32-557"
+        "Performance Monitor Users" = "S-1-5-32-558"
+        "Performance Log Users" = "S-1-5-32-559"
+        "Windows Authorization Access Group" = "S-1-5-32-560"
+        "Terminal Server License Servers" = "S-1-5-32-561"
+        "Distributed COM Users" = "S-1-5-32-562"
+        "IIS_IUSRS" = "S-1-5-32-568"
+        "Cryptographic Operators" = "S-1-5-32-569"
+        "Event Log Readers" = "S-1-5-32-573"
+        "Certificate Service DCOM Access" = "S-1-5-32-574"
+        "RDS Remote Access Servers" = "S-1-5-32-575"
+        "RDS Endpoint Servers" = "S-1-5-32-576"
+        "RDS Management Servers" = "S-1-5-32-577"
+        "Hyper-V Administrators" = "S-1-5-32-578"
+        "Access Control Assistance Operators" = "S-1-5-32-579"
+        "Remote Management Users" = "S-1-5-32-580"
+        "Storage Replica Administrators" = "S-1-5-32-582"
+        "Device Owners" = "S-1-5-32-583"
+        "User Mode Hardware Operators" = "S-1-5-32-584"
+        "OpenSSH Users" = "S-1-5-32-585"
         "SYSTEM" = "S-1-5-18"
         "Authenticated Users" = "S-1-5-11"
         "ANONYMOUS LOGON" = "S-1-5-7"
         "Local account" = "S-1-5-113"
         "IUSR" = "S-1-5-17"
+        "ENTERPRISE DOMAIN CONTROLLERS" = "S-1-5-9"
     }
     
     # Try exact match first
@@ -314,6 +396,117 @@ function Get-WellKnownSid {
     return $null
 }
 
+function Get-TierModelDomainSid {
+    <#
+    .SYNOPSIS
+    Returns the domain SID (or forest root domain SID) for a domain controller, with caching
+
+    .DESCRIPTION
+    Queries the domain SID once per domain controller and caches it for the session.
+    With -ForestRoot, returns the SID of the forest root domain instead (needed for
+    forest-level groups such as Enterprise Admins and Schema Admins).
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DomainController,
+
+        [switch]$ForestRoot
+    )
+
+    if (-not $script:DomainSidCache) {
+        $script:DomainSidCache = @{}
+    }
+
+    $cacheKey = "$DomainController|ForestRoot=$([bool]$ForestRoot)"
+    if ($script:DomainSidCache.ContainsKey($cacheKey)) {
+        return $script:DomainSidCache[$cacheKey]
+    }
+
+    $domain = Get-ADDomain -Server $DomainController -ErrorAction Stop
+
+    if ($ForestRoot) {
+        $forest = Get-ADForest -Server $DomainController -ErrorAction Stop
+        if ($forest.RootDomain -and $forest.RootDomain -ne $domain.DNSRoot) {
+            # Child domain: forest-level groups live in the forest root domain
+            $domain = Get-ADDomain -Identity $forest.RootDomain -ErrorAction Stop
+        }
+    }
+
+    $domainSid = $domain.DomainSID.Value
+    if (-not $domainSid) {
+        throw "Could not determine domain SID via domain controller '$DomainController'"
+    }
+
+    $script:DomainSidCache[$cacheKey] = $domainSid
+    return $domainSid
+}
+
+function Get-WellKnownDomainRidSid {
+    <#
+    .SYNOPSIS
+    Resolves well-known domain groups to their SID via fixed RIDs (language-independent)
+
+    .DESCRIPTION
+    Maps canonical (English) names of well-known domain groups to <DomainSID>-<RID>.
+    This makes resolution independent of the AD display language (e.g. "Domain Admins"
+    is "Domänen-Admins" in a German AD, but always <DomainSID>-512).
+    Forest-level groups (Enterprise Admins, Schema Admins, ...) are resolved against
+    the forest root domain SID.
+    Returns $null if the principal is not a well-known domain group.
+    #>
+
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Principal,
+
+        [Parameter(Mandatory)]
+        [string]$DomainController
+    )
+
+    # Domain-relative well-known RIDs (hashtable literal keys are case-insensitive)
+    $domainRids = @{
+        "Guest"                         = 501
+        "krbtgt"                        = 502
+        "Domain Admins"                 = 512
+        "Domain Users"                  = 513
+        "Domain Guests"                 = 514
+        "Domain Computers"              = 515
+        "Domain Controllers"            = 516
+        "Cert Publishers"               = 517
+        "Group Policy Creator Owners"   = 520
+        "Read-only Domain Controllers"  = 521
+        "Cloneable Domain Controllers"  = 522
+        "Protected Users"               = 525
+        "Key Admins"                    = 526
+        "RAS and IAS Servers"           = 553
+        "Allowed RODC Password Replication Group" = 571
+        "Denied RODC Password Replication Group"  = 572
+    }
+
+    # Forest-root-relative well-known RIDs
+    $forestRootRids = @{
+        "Enterprise Read-only Domain Controllers" = 498
+        "Schema Admins"                           = 518
+        "Enterprise Admins"                       = 519
+        "Enterprise Key Admins"                   = 527
+    }
+
+    if ($domainRids.ContainsKey($Principal)) {
+        $domainSid = Get-TierModelDomainSid -DomainController $DomainController
+        return "$domainSid-$($domainRids[$Principal])"
+    }
+
+    if ($forestRootRids.ContainsKey($Principal)) {
+        $rootDomainSid = Get-TierModelDomainSid -DomainController $DomainController -ForestRoot
+        return "$rootDomainSid-$($forestRootRids[$Principal])"
+    }
+
+    return $null
+}
+
 function Resolve-ADPrincipalSid {
     <#
     .SYNOPSIS
@@ -327,10 +520,12 @@ function Resolve-ADPrincipalSid {
     param(
         [Parameter(Mandatory)]
         [string]$Principal,
-        
+
+        [string]$DomainController,
+
         [string]$CorrelationId
     )
-    
+
     try {
         # Load ActiveDirectory module if available
         if (-not (Get-Module -Name ActiveDirectory -ListAvailable)) {
@@ -461,5 +656,6 @@ function Get-TierModelConditionalGroupNames {
     return $resolvedNames
 }
 
-# Initialize module-level SID cache
+# Initialize module-level SID caches
 $script:SidCache = @{}
+$script:DomainSidCache = @{}

--- a/modules/TierModel/public/Test-TierModelPrerequisites.ps1
+++ b/modules/TierModel/public/Test-TierModelPrerequisites.ps1
@@ -252,7 +252,23 @@ function Test-TierModelPrerequisites {
                 Import-Module ActiveDirectory -ErrorAction SilentlyContinue -Verbose:$false | Out-Null
                 if (Get-Module ActiveDirectory) {
                     $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-                    $domainAdmins = Get-ADGroup -Identity "Domain Admins" -Server $PreferredDc -ErrorAction SilentlyContinue
+
+                    # Resolve Domain Admins via well-known RID 512 (language-independent:
+                    # the group is e.g. "Domänen-Admins" in a German AD)
+                    $domainAdmins = $null
+                    try {
+                        $domainInfo = Get-ADDomain -Server $PreferredDc -ErrorAction Stop
+                        if ($domainInfo -and $domainInfo.PSObject.Properties['DomainSID'] -and $domainInfo.DomainSID) {
+                            $domainAdminsSid = "$($domainInfo.DomainSID.Value)-512"
+                            $domainAdmins = Get-ADGroup -Identity $domainAdminsSid -Server $PreferredDc -ErrorAction SilentlyContinue
+                        }
+                    }
+                    catch {
+                        # Fall back to name-based lookup below
+                    }
+                    if (-not $domainAdmins) {
+                        $domainAdmins = Get-ADGroup -Identity "Domain Admins" -Server $PreferredDc -ErrorAction SilentlyContinue
+                    }
                     
                     if ($domainAdmins) {
                         $isDomainAdmin = Get-ADGroupMember -Identity $domainAdmins -Server $PreferredDc -Recursive -ErrorAction SilentlyContinue | 
@@ -328,7 +344,31 @@ function Test-TierModelPrerequisites {
                         
                         # Check for Enterprise Admins group (may not exist in child domains)
                         try {
-                            $enterpriseAdmins = Get-ADGroup -Identity "Enterprise Admins" -Server $PreferredDc -ErrorAction SilentlyContinue
+                            # Resolve via well-known RID 519 on the forest root domain SID
+                            # (language-independent: e.g. "Organisations-Admins" in a German AD)
+                            $enterpriseAdmins = $null
+                            try {
+                                $rootDomainSid = $null
+                                if (-not $isChildDomain) {
+                                    if ($domain.PSObject.Properties['DomainSID'] -and $domain.DomainSID) {
+                                        $rootDomainSid = $domain.DomainSID.Value
+                                    }
+                                } else {
+                                    $rootDomain = Get-ADDomain -Identity $forest.RootDomain -ErrorAction SilentlyContinue
+                                    if ($rootDomain -and $rootDomain.PSObject.Properties['DomainSID'] -and $rootDomain.DomainSID) {
+                                        $rootDomainSid = $rootDomain.DomainSID.Value
+                                    }
+                                }
+                                if ($rootDomainSid) {
+                                    $enterpriseAdmins = Get-ADGroup -Identity "$rootDomainSid-519" -Server $PreferredDc -ErrorAction SilentlyContinue
+                                }
+                            }
+                            catch {
+                                # Fall back to name-based lookup below
+                            }
+                            if (-not $enterpriseAdmins) {
+                                $enterpriseAdmins = Get-ADGroup -Identity "Enterprise Admins" -Server $PreferredDc -ErrorAction SilentlyContinue
+                            }
                             $result.EnvironmentSnapshot.HasEnterpriseAdmins = [bool]$enterpriseAdmins
                         }
                         catch {
@@ -442,7 +482,7 @@ function Test-TierModelPrerequisites {
                 if (-not $result.EnvironmentSnapshot.KdsRootKeyExists) {
                     $result.Valid = $false
                     $null = $result.Errors.Add("No KDS Root Key found. gMSA requires an effective KDS Root Key.")
-                    $null = $result.Remediation.Add("Create a KDS Root Key: Add-KdsRootKey -EffectiveImmediately (for lab) or Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10)) (for production). The Tier Model will NEVER create KDS keys automatically.")
+                    $null = $result.Remediation.Add("Create a KDS Root Key: Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10)). Deploy-TierModel.ps1 creates this automatically in execution mode (-ConfirmApply); create it manually only if auto-provisioning failed.")
                 } else {
                     $latestKey = @($kdsKeys) | Sort-Object EffectiveTime -Descending | Select-Object -First 1
                     $result.EnvironmentSnapshot.KdsRootKeyEffective = ($latestKey.EffectiveTime -lt (Get-Date).AddHours(-10))

--- a/modules/TierModel/public/Test-TierModelPrerequisites.ps1
+++ b/modules/TierModel/public/Test-TierModelPrerequisites.ps1
@@ -349,18 +349,23 @@ function Test-TierModelPrerequisites {
                             $enterpriseAdmins = $null
                             try {
                                 $rootDomainSid = $null
+                                # Enterprise Admins lives in the forest root domain, so both the
+                                # SID lookup and the group query must target a root-domain DC
+                                # when running from a child domain
+                                $eaServer = $PreferredDc
                                 if (-not $isChildDomain) {
                                     if ($domain.PSObject.Properties['DomainSID'] -and $domain.DomainSID) {
                                         $rootDomainSid = $domain.DomainSID.Value
                                     }
                                 } else {
-                                    $rootDomain = Get-ADDomain -Identity $forest.RootDomain -ErrorAction SilentlyContinue
+                                    $rootDomain = Get-ADDomain -Identity $forest.RootDomain -Server $forest.RootDomain -ErrorAction SilentlyContinue
                                     if ($rootDomain -and $rootDomain.PSObject.Properties['DomainSID'] -and $rootDomain.DomainSID) {
                                         $rootDomainSid = $rootDomain.DomainSID.Value
+                                        $eaServer = $forest.RootDomain
                                     }
                                 }
                                 if ($rootDomainSid) {
-                                    $enterpriseAdmins = Get-ADGroup -Identity "$rootDomainSid-519" -Server $PreferredDc -ErrorAction SilentlyContinue
+                                    $enterpriseAdmins = Get-ADGroup -Identity "$rootDomainSid-519" -Server $eaServer -ErrorAction SilentlyContinue
                                 }
                             }
                             catch {

--- a/tests/Unit.Prerequisites.Tests.ps1
+++ b/tests/Unit.Prerequisites.Tests.ps1
@@ -239,12 +239,43 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
     It "Should fail when current user not Domain Admin" -Tag 'Negative','DomainAdmin' {
             # Call the function to get result - with default mocks, Get-ADGroup returns null
             $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $validDepsFile
-            
+
             $result.EnvironmentSnapshot.IsDomainAdmin | Should -Be $false
             $result.Valid | Should -Be $false
             $result.Errors | Should -Contain "Domain Admin membership required for deployment operations"
             # With Get-ADGroup returning null from BeforeEach, expect this remediation message
             $result.Remediation | Should -Contain "Ensure Domain Admins group exists and user is member of Domain Admins group"
+        }
+
+    It "Should find Domain Admins via well-known RID 512 in a localized (e.g. German) AD" -Tag 'Positive','DomainAdmin' {
+            # Simulate a German AD: no group is named "Domain Admins", but the
+            # well-known SID <DomainSID>-512 resolves to "Domänen-Admins"
+            Mock Get-ADDomain {
+                return [PSCustomObject]@{
+                    DNSRoot      = 'test.contoso.com'
+                    NetBIOSName  = 'TEST'
+                    DomainSID    = [PSCustomObject]@{ Value = 'S-1-5-21-111-222-333' }
+                }
+            } -ModuleName TierModel
+            Mock Get-ADGroup {
+                if ($Identity -eq 'S-1-5-21-111-222-333-512') {
+                    return [PSCustomObject]@{
+                        Name              = 'Domänen-Admins'
+                        DistinguishedName = 'CN=Domänen-Admins,CN=Users,DC=test,DC=contoso,DC=com'
+                    }
+                }
+                return $null
+            } -ModuleName TierModel
+            Mock Get-ADGroupMember { return @() } -ModuleName TierModel
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $validDepsFile
+
+            # Group was found via SID, so the membership check ran; the test user
+            # is not a member, which yields the "add user" remediation (not the
+            # "group not found" one)
+            $result.EnvironmentSnapshot.IsDomainAdmin | Should -Be $false
+            ($result.Remediation -join ' ') | Should -Match 'Add current user to Domain Admins'
+            $result.Remediation | Should -Not -Contain "Ensure Domain Admins group exists and user is member of Domain Admins group"
         }
     }
     

--- a/tests/Unit.Resolution.Tests.ps1
+++ b/tests/Unit.Resolution.Tests.ps1
@@ -897,9 +897,10 @@ Describe "Get-TierModelConditionalGroupNames" -Tag 'Unit', 'Resolution', 'Condit
 Describe "Resolve-TierModelPrincipalSid" -Tag 'Unit', 'Resolution', 'PrincipalSid' {
 
     BeforeEach {
-        # Clear the module-level SID cache before each test
+        # Clear the module-level SID caches before each test
         InModuleScope TierModel {
             $script:SidCache = @{}
+            $script:DomainSidCache = @{}
         }
         Mock Write-TierModelLog { } -ModuleName TierModel
         Mock Write-Warning      { } -ModuleName TierModel
@@ -1164,6 +1165,149 @@ Describe "Resolve-TierModelPrincipalSid" -Tag 'Unit', 'Resolution', 'PrincipalSi
             $result.Source  | Should -Be 'WellKnown'
             $result.Sid     | Should -Be 'S-1-5-20'
             $result.Success | Should -BeTrue
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # Well-known domain RID resolution (language-independent)
+    # Groups like "Domain Admins" are localized in non-English ADs
+    # (e.g. "Domänen-Admins" in German) — resolution must use fixed RIDs
+    # ------------------------------------------------------------------
+    Context "Well-Known Domain RID Resolution" {
+
+        BeforeEach {
+            Mock Get-ADDomain {
+                [PSCustomObject]@{
+                    DNSRoot   = 'contoso.com'
+                    DomainSID = [PSCustomObject]@{ Value = 'S-1-5-21-111-222-333' }
+                }
+            } -ModuleName TierModel
+            Mock Get-ADForest {
+                [PSCustomObject]@{ RootDomain = 'contoso.com' }
+            } -ModuleName TierModel
+            Mock Get-ADGroup { throw 'Group should not be looked up by name' } -ModuleName TierModel
+        }
+
+        It "Should resolve Domain Admins via RID 512 without a name-based AD lookup" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Domain Admins' -DomainController 'dc01.contoso.com'
+            $result.Success | Should -BeTrue
+            $result.Source  | Should -Be 'WellKnownRid'
+            $result.Sid     | Should -Be 'S-1-5-21-111-222-333-512'
+            Should -Invoke Get-ADGroup -ModuleName TierModel -Times 0 -Exactly
+        }
+
+        It "Should resolve Domain Users via RID 513" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Domain Users' -DomainController 'dc01.contoso.com'
+            $result.Sid | Should -Be 'S-1-5-21-111-222-333-513'
+        }
+
+        It "Should resolve Domain Controllers via RID 516" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Domain Controllers' -DomainController 'dc01.contoso.com'
+            $result.Sid | Should -Be 'S-1-5-21-111-222-333-516'
+        }
+
+        It "Should resolve Protected Users via RID 525" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Protected Users' -DomainController 'dc01.contoso.com'
+            $result.Sid | Should -Be 'S-1-5-21-111-222-333-525'
+        }
+
+        It "Should resolve Cloneable Domain Controllers via RID 522" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Cloneable Domain Controllers' -DomainController 'dc01.contoso.com'
+            $result.Sid | Should -Be 'S-1-5-21-111-222-333-522'
+        }
+
+        It "Should resolve Guest via RID 501" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Guest' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'WellKnownRid'
+            $result.Sid    | Should -Be 'S-1-5-21-111-222-333-501'
+        }
+
+        It "Should resolve Allowed RODC Password Replication Group via RID 571" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Allowed RODC Password Replication Group' -DomainController 'dc01.contoso.com'
+            $result.Sid | Should -Be 'S-1-5-21-111-222-333-571'
+        }
+
+        It "Should resolve short-form Cryptographic Operators as well-known BUILTIN SID" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Cryptographic Operators' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'WellKnown'
+            $result.Sid    | Should -Be 'S-1-5-32-569'
+        }
+
+        It "Should resolve short-form Backup Operators as well-known BUILTIN SID" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Backup Operators' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'WellKnown'
+            $result.Sid    | Should -Be 'S-1-5-32-551'
+        }
+
+        It "Should resolve principal names case-insensitively" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'domain admins' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'WellKnownRid'
+            $result.Sid    | Should -Be 'S-1-5-21-111-222-333-512'
+        }
+
+        It "Should resolve Enterprise Admins via RID 519 on the current domain SID when it is the forest root" {
+            $result = Resolve-TierModelPrincipalSid -Principal 'Enterprise Admins' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'WellKnownRid'
+            $result.Sid    | Should -Be 'S-1-5-21-111-222-333-519'
+        }
+
+        It "Should resolve Schema Admins via RID 518 on the forest root domain SID in a child domain" {
+            Mock Get-ADDomain {
+                if ($Identity) {
+                    # Forest root domain lookup
+                    [PSCustomObject]@{
+                        DNSRoot   = 'contoso.com'
+                        DomainSID = [PSCustomObject]@{ Value = 'S-1-5-21-999-888-777' }
+                    }
+                } else {
+                    # Current (child) domain
+                    [PSCustomObject]@{
+                        DNSRoot   = 'child.contoso.com'
+                        DomainSID = [PSCustomObject]@{ Value = 'S-1-5-21-111-222-333' }
+                    }
+                }
+            } -ModuleName TierModel
+            Mock Get-ADForest {
+                [PSCustomObject]@{ RootDomain = 'contoso.com' }
+            } -ModuleName TierModel
+
+            $result = Resolve-TierModelPrincipalSid -Principal 'Schema Admins' -DomainController 'dc01.child.contoso.com'
+            $result.Source | Should -Be 'WellKnownRid'
+            $result.Sid    | Should -Be 'S-1-5-21-999-888-777-518'
+        }
+
+        It "Should query the domain SID only once for multiple RID resolutions (cache)" {
+            $null = Resolve-TierModelPrincipalSid -Principal 'Domain Admins' -DomainController 'dc01.contoso.com'
+            $null = Resolve-TierModelPrincipalSid -Principal 'Domain Users' -DomainController 'dc01.contoso.com'
+            Should -Invoke Get-ADDomain -ModuleName TierModel -Times 1 -Exactly
+        }
+
+        It "Should fall back to AD resolution when the domain SID cannot be determined" {
+            Mock Get-ADDomain { throw 'DC unreachable' } -ModuleName TierModel
+            Mock Resolve-ADPrincipalSid {
+                @{ Sid = 'S-1-5-21-444-555-666-512'; Source = 'ADGroup'; Success = $true; Error = $null }
+            } -ModuleName TierModel
+
+            $result = Resolve-TierModelPrincipalSid -Principal 'Domain Admins' -DomainController 'dc01.contoso.com'
+            $result.Success | Should -BeTrue
+            $result.Source  | Should -Be 'ADGroup'
+            Should -Invoke Resolve-ADPrincipalSid -ModuleName TierModel -Times 1 -Exactly
+        }
+
+        It "Should not treat non-well-known groups as domain RIDs" {
+            Mock Resolve-ADPrincipalSid {
+                @{ Sid = 'S-1-5-21-111-222-333-1105'; Source = 'ADGroup'; Success = $true; Error = $null }
+            } -ModuleName TierModel
+
+            $result = Resolve-TierModelPrincipalSid -Principal 'Tier 0 Admins' -DomainController 'dc01.contoso.com'
+            $result.Source | Should -Be 'ADGroup'
+        }
+
+        It "Should cache RID-resolved SIDs and return Cached = true on second call" {
+            $null = Resolve-TierModelPrincipalSid -Principal 'Domain Admins' -DomainController 'dc01.contoso.com'
+            $result = Resolve-TierModelPrincipalSid -Principal 'Domain Admins' -DomainController 'dc01.contoso.com'
+            $result.Cached | Should -BeTrue
+            $result.Sid    | Should -Be 'S-1-5-21-111-222-333-512'
         }
     }
 


### PR DESCRIPTION

Deployments, prerequisite checks and WinLAPS delegations failed on non-English Active Directory domains (e.g. German: "Domain Admins" is "Domänen-Admins", "Enterprise Admins" is "Organisations-Admins") because well-known principals were looked up by their English display names. All well-known principals are now resolved language-independently via their fixed SIDs/RIDs. Validated against a real German AD (full deployment run).

SID/RID resolution (Resolve-TierModelPrincipalSid):
- New WellKnownRid resolution stage that maps canonical names of well-known domain groups to <DomainSID>-<RID> before any name-based AD lookup (Guest=501, krbtgt=502, Domain Admins=512, Domain Users=513, Domain Controllers=516, Cert Publishers=517, GP Creator Owners=520, RODCs=521, Cloneable DCs=522, Protected Users=525, Key Admins=526, RAS and IAS Servers=553, Allowed/Denied RODC Password Replication Group=571/572).
- Forest-level groups (Enterprise RODCs=498, Schema Admins=518, Enterprise Admins=519, Enterprise Key Admins=527) resolve against the forest root domain SID, correct also from child domains.
- Well-known SID table extended with all BUILTIN groups (Cryptographic Operators, Certificate Service DCOM Access, RDS groups, Hyper-V Administrators, Remote Management Users, Device Owners, User Mode Hardware Operators, OpenSSH Users, ...) including short-name aliases as used in tiermodel-gpos.json (e.g. "Backup Operators").
- Domain SIDs are cached per domain controller; on failure the existing name-based resolution is used as fallback.
- Resolve-ADPrincipalSid: DomainController is now an explicit parameter instead of relying on dynamic scoping.

Prerequisites (Test-TierModelPrerequisites):
- Domain Admins membership check and Enterprise Admins detection resolve via RID 512/519 first, with name-based fallback.

GPO deployment:
- New-TierModelGpo: the Deny "Apply Group Policy" ACE is built from a SecurityIdentifier resolved via Resolve-TierModelPrincipalSid instead of an NTAccount name, which failed to translate on localized domains ("Some or all identity references could not be translated").
- tiermodel-gpos.json: literal "Power Users" / "User Mode Hardware Operators" restricted-group entries replaced with their well-known SIDs (*S-1-5-32-547 / *S-1-5-32-584) so target machines do not have to resolve English names client-side.

Windows LAPS:
- Get-TierModelWinLapsAcl/Fd resolved readGroup/resetGroup/ decryptorGroup via Get-ADGroup -Filter "Name -eq '...'" — fails for well-known groups on non-English ADs, leaving allowedPrincipals empty and crashing Set-LapsADReadPasswordPermission with "Cannot bind argument ... empty array". Well-known groups are now resolved via their fixed SID/RID first, with name lookup as fallback.
- New-TierModelWinLapsAcl fails the action with a clear error when a Read/Reset permission has no resolvable principals instead of surfacing a parameter binding exception.

Auto-provisioning (execution mode only, -ConfirmApply):
- -IncludeGmsa/-IncludeDmsa: if no KDS Root Key exists, Deploy-TierModel creates one on the preferred DC via Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10)) so it is effective immediately.
- -IncludeWinLaps: if the msLAPS-* schema attributes are missing, the AD schema is extended automatically via Update-LapsADSchema (requires Schema Admins).
- Prerequisites remediation text updated accordingly.

Tests:
- 17 new unit tests for RID/BUILTIN resolution (child domain, caching, fallback, case-insensitivity) and a prerequisites test simulating a German AD (group only findable as "Domänen-Admins" via RID 512).

The English group names in the config files remain unchanged and act as canonical identifiers; no config changes are required for existing deployments.