### PR TITLE
docs: establish issue-first contribution process (CONTRIBUTING + PR template + Pages)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+  Thanks for contributing! Before opening this PR, please confirm you followed the
+  issue-first process in CONTRIBUTING.md:
+  https://github.com/microsoft/ActiveDirectoryTierModel/blob/main/CONTRIBUTING.md
+
+  Pull requests WITHOUT a linked, pre-agreed issue will be closed. This is a
+  security-sensitive tiering tool — changes must be discussed before code is written.
+-->
+
+## Linked issue
+
+<!-- Every PR must reference an issue that was discussed and AGREED before you wrote code. -->
+
+Closes #
+
+## What this PR does
+
+<!-- One concern per PR. Describe the single change and how it matches the agreed issue. -->
+
+## Security / tiering impact
+
+<!-- Does this touch OUs, ACLs / delegations, GPOs, prerequisites, or add a parameter or
+     topology option? Describe the impact on the tier boundaries and security posture. -->
+
+## Checklist
+
+- [ ] This change was **discussed and agreed in the linked issue before I wrote code**
+- [ ] The PR addresses **one concern** (no bundled or unrelated changes)
+- [ ] I did **not** add new public parameters, alternate topologies, or relax
+      prerequisite / validation logic unless it was the agreed subject of the issue
+- [ ] Tests added or updated; `.\tests\Invoke-AllTests.ps1` passes and coverage stays **≥ 80%**
+- [ ] No unrelated reformatting or whitespace churn
+- [ ] Documentation updated for any changed behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to the Active Directory Tier Model
+
+Thank you for your interest in improving this project. This is a **security-sensitive
+reference implementation** of Microsoft's tiered administration model, so we follow a
+deliberate, **issue-first** process to keep the model coherent, secure, and maintainable.
+Please read this before opening a pull request.
+
+## The change process, in short
+
+1. **Open an issue first.** Every change — feature, bug fix, refactor, config, or docs —
+   starts with a GitHub Issue that describes the problem or proposal.
+2. **Discuss and get agreement.** A maintainer will review the issue and agree on the
+   scope and approach. **Wait for a clear go-ahead** (the issue is accepted) **before you
+   write code.**
+3. **Then open a focused pull request** that links the agreed issue and implements only
+   what was agreed.
+
+> **Pull requests without a linked, pre-agreed issue will be closed.** This is not
+> personal — please see *Why we work this way* below.
+
+## Why we work this way
+
+- **Security first.** This project deploys and audits privileged-access tiering
+  (Tier 0 / 1 / 2) boundaries in Active Directory. An unreviewed change can silently
+  weaken a tier boundary, broaden the attack surface, or relax a validation that exists
+  on purpose. Every change needs a design- and threat-aware review **before** code, not
+  after.
+- **The model is intentionally opinionated.** It implements a specific, tested topology
+  and set of conventions. Alternative approaches — new parameters, alternate OU layouts,
+  relaxed prerequisites, different naming — may well be reasonable, but they change the
+  security posture and must be discussed and justified in an issue first so we can weigh
+  them as a project.
+- **We respect your time.** Agreeing on scope up front avoids you investing hours in a PR
+  we can't accept because it conflicts with the design, duplicates in-flight work, or
+  bundles too much. A five-minute issue saves everyone a large, hard-to-review PR.
+
+## Opening a good issue
+
+Please include:
+
+- **What** you want to change and **why** (the problem or use case).
+- **Scope** — the smallest change that solves it.
+- **Security / tiering impact** — does it touch OUs, ACLs / delegations, GPOs,
+  prerequisites, or add a parameter or topology option?
+- **Environment details** if it's a bug (OS, PowerShell version, AD functional level, and
+  the domain controller's install language).
+
+If you're reporting something that's already fixed, we'll close the issue with a pointer to
+the fix or release — please check the latest release and [`CHANGELOG.md`](CHANGELOG.md)
+first.
+
+## Pull request requirements
+
+Once an issue is agreed, your PR must:
+
+1. **Link the agreed issue** (e.g. `Closes #123`) and stay within the agreed scope.
+2. **Be focused — one concern per PR.** Don't bundle unrelated changes (e.g. a bug fix
+   *plus* a new parameter *plus* reformatting). Split them into separate issues and PRs.
+3. **Contain no unsolicited scope changes.** New public parameters, alternate deployment
+   topologies, relaxed or bypassed prerequisite/validation logic, and mass config
+   reformatting will be rejected unless they were the agreed subject of the issue. In
+   particular, changes that turn a deliberate **fail-fast / hard-stop into a "warn and
+   continue"** weaken safety and require explicit design sign-off.
+4. **Include tests.** New code and bug fixes need Pester tests; keep coverage at or above
+   the **80%** CI gate.
+5. **Keep the diff clean.** No incidental whitespace or reformatting churn in files
+   unrelated to your change.
+6. **Update documentation** for any changed behavior.
+7. **Pass CI** — lint, tests, coverage, and security checks are enforced. The release
+   artifact is only produced when these pass.
+
+## What tends to get rejected
+
+- PRs with **no prior issue and no agreement**.
+- **Bundled** PRs mixing unrelated features, fixes, and reformatting.
+- **New parameters or alternate topologies** that were never discussed — they change the
+  model's contract and its security surface.
+- Changes that **relax security-relevant validation** (for example, converting a fail-fast
+  prerequisite gate into a silent skip).
+- Large **reformat-only** diffs across config / JSON that obscure the real change.
+
+## Development quick reference
+
+```powershell
+# Run the full test suite (must pass, coverage >= 80%)
+.\tests\Invoke-AllTests.ps1
+
+# Unit or integration only
+.\tests\Invoke-AllTests.ps1 -TestType Unit
+.\tests\Invoke-AllTests.ps1 -TestType Integration
+```
+
+Tests use mocks and require no live Active Directory connectivity.
+
+## Working agreement
+
+- Be respectful and assume good intent — from contributors and maintainers alike.
+- Maintainers may decline changes that don't fit the project's security model or roadmap,
+  even when they are well implemented. We will always explain why.
+- This project follows the
+  [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Thank you for helping keep the Tier Model secure and coherent. 🙏

--- a/README.md
+++ b/README.md
@@ -84,13 +84,29 @@ To get started with TierModel, please refer to our comprehensive documentation:
 
 ## 🤝 Contributing
 
-Contributions are welcome! Before submitting a pull request, you **must** ensure:
+Contributions are welcome — but this is a **security-sensitive** project, so we follow an
+**issue-first** process. Please read **[CONTRIBUTING.md](CONTRIBUTING.md)** before opening a
+pull request.
+
+**The process, in short:**
+
+1. 🗣️ **Open an issue first** describing the problem or proposal — for *any* change (feature, fix, refactor, config, or docs).
+2. 🧭 **Discuss and get maintainer agreement** on scope and approach **before writing code**.
+3. 🔀 **Then open a focused PR** that links the agreed issue and implements only what was agreed.
+
+> ⚠️ **Pull requests without a linked, pre-agreed issue will be closed.** Unsolicited new
+> parameters, alternate deployment topologies, relaxed security validation, or
+> bundled / reformat-heavy changes are rejected on sight — not to be unwelcoming, but
+> because unreviewed changes to a tiering-security tool can silently weaken tier
+> boundaries. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full rationale.
+
+When your PR is ready, it must also satisfy:
 
 1. ✅ **All Pester tests pass** — the CI pipeline will reject any PR with failing tests
 2. 🧪 **New or updated tests are included** — any new code or bug fix must include corresponding test cases to maintain or improve code coverage
 3. 📊 **Code coverage stays at or above 80%** — the CI enforces a minimum coverage threshold; if your changes reduce coverage below 80%, add tests until coverage is restored
 4. 📝 Documentation is updated for any new or changed functionality
-5. 🎯 Code follows project conventions
+5. 🎯 Code follows project conventions and keeps the diff focused (no unrelated reformatting)
 
 > **Note:** The packaging step will not produce a release artifact unless all tests pass and coverage meets the minimum threshold.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,93 @@
+# Contributing
+
+> This page mirrors [`CONTRIBUTING.md`](https://github.com/microsoft/ActiveDirectoryTierModel/blob/main/CONTRIBUTING.md)
+> in the repository root, which GitHub surfaces automatically when you open an issue or
+> pull request. That file is the authoritative version.
+
+Thank you for your interest in improving this project. This is a **security-sensitive
+reference implementation** of Microsoft's tiered administration model, so we follow a
+deliberate, **issue-first** process to keep the model coherent, secure, and maintainable.
+Please read this before opening a pull request.
+
+## The change process, in short
+
+1. **Open an issue first.** Every change — feature, bug fix, refactor, config, or docs —
+   starts with a GitHub Issue that describes the problem or proposal.
+2. **Discuss and get agreement.** A maintainer will review the issue and agree on the
+   scope and approach. **Wait for a clear go-ahead** (the issue is accepted) **before you
+   write code.**
+3. **Then open a focused pull request** that links the agreed issue and implements only
+   what was agreed.
+
+!!! warning "Pull requests without a linked, pre-agreed issue will be closed."
+    This is not personal — please see *Why we work this way* below.
+
+## Why we work this way
+
+- **Security first.** This project deploys and audits privileged-access tiering
+  (Tier 0 / 1 / 2) boundaries in Active Directory. An unreviewed change can silently
+  weaken a tier boundary, broaden the attack surface, or relax a validation that exists
+  on purpose. Every change needs a design- and threat-aware review **before** code, not
+  after.
+- **The model is intentionally opinionated.** It implements a specific, tested topology
+  and set of conventions. Alternative approaches — new parameters, alternate OU layouts,
+  relaxed prerequisites, different naming — may well be reasonable, but they change the
+  security posture and must be discussed and justified in an issue first so we can weigh
+  them as a project.
+- **We respect your time.** Agreeing on scope up front avoids you investing hours in a PR
+  we can't accept because it conflicts with the design, duplicates in-flight work, or
+  bundles too much. A five-minute issue saves everyone a large, hard-to-review PR.
+
+## Opening a good issue
+
+Please include:
+
+- **What** you want to change and **why** (the problem or use case).
+- **Scope** — the smallest change that solves it.
+- **Security / tiering impact** — does it touch OUs, ACLs / delegations, GPOs,
+  prerequisites, or add a parameter or topology option?
+- **Environment details** if it's a bug (OS, PowerShell version, AD functional level, and
+  the domain controller's install language).
+
+If you're reporting something that's already fixed, we'll close the issue with a pointer to
+the fix or release — please check the latest release and the project changelog first.
+
+## Pull request requirements
+
+Once an issue is agreed, your PR must:
+
+1. **Link the agreed issue** (e.g. `Closes #123`) and stay within the agreed scope.
+2. **Be focused — one concern per PR.** Don't bundle unrelated changes (e.g. a bug fix
+   *plus* a new parameter *plus* reformatting). Split them into separate issues and PRs.
+3. **Contain no unsolicited scope changes.** New public parameters, alternate deployment
+   topologies, relaxed or bypassed prerequisite/validation logic, and mass config
+   reformatting will be rejected unless they were the agreed subject of the issue. In
+   particular, changes that turn a deliberate **fail-fast / hard-stop into a "warn and
+   continue"** weaken safety and require explicit design sign-off.
+4. **Include tests.** New code and bug fixes need Pester tests; keep coverage at or above
+   the **80%** CI gate.
+5. **Keep the diff clean.** No incidental whitespace or reformatting churn in files
+   unrelated to your change.
+6. **Update documentation** for any changed behavior.
+7. **Pass CI** — lint, tests, coverage, and security checks are enforced. The release
+   artifact is only produced when these pass.
+
+## What tends to get rejected
+
+- PRs with **no prior issue and no agreement**.
+- **Bundled** PRs mixing unrelated features, fixes, and reformatting.
+- **New parameters or alternate topologies** that were never discussed — they change the
+  model's contract and its security surface.
+- Changes that **relax security-relevant validation** (for example, converting a fail-fast
+  prerequisite gate into a silent skip).
+- Large **reformat-only** diffs across config / JSON that obscure the real change.
+
+## Working agreement
+
+- Be respectful and assume good intent — from contributors and maintainers alike.
+- Maintainers may decline changes that don't fit the project's security model or roadmap,
+  even when they are well implemented. We will always explain why.
+- This project follows the
+  [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Thank you for helping keep the Tier Model secure and coherent. 🙏

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 Welcome to the Active Directory Tier Model documentation.
 
+## Contributing
+
+- **[Contributing & Change Process](contributing.md)** - How to propose changes: open an issue first, agree on scope, then submit a focused pull request. **Please read this before opening a PR.**
+
 ## Getting Started
 
 - **[Quick Deployment Guide](quick-deployment-guide.md)** - Fast-track deployment instructions for experienced administrators

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Contributing: contributing.md
   - Quick Deployment Guide: quick-deployment-guide.md
   - Detailed Deployment Guide: detailed-deployment-guide.md
   - FAQ: faq.md


### PR DESCRIPTION
## Establish an issue-first contribution process

Adds and publishes an explicit, professional **issue-first** change process so that
contributions are discussed and agreed **before** code is written — and so unsolicited,
bundled, or scope-expanding changes can be declined consistently and transparently.

### What's included
- **`CONTRIBUTING.md`** (repo root) — the canonical policy GitHub surfaces automatically on
  every new issue and pull request. Covers the 3-step process (open an issue → agree scope
  → focused PR), the **security rationale** (this is a tiering-security tool; unreviewed
  changes can weaken tier boundaries), how to open a good issue, PR requirements, and a
  clear **"what tends to get rejected"** list.
- **`.github/pull_request_template.md`** — every new PR now prompts for a linked, agreed
  issue, a single-concern description, a **security / tiering impact** statement, and a
  compliance checklist.
- **GitHub Pages** — `docs/contributing.md` (wired into `mkdocs.yml` nav and linked from
  `docs/index.md`) publishes the same policy to the documentation site.
- **`README.md`** — the Contributing section now leads with the issue-first process and a
  clear notice that PRs without a linked, pre-agreed issue will be closed.

### Notes
- **No code or version change** — this does not trigger a release. The Pages site
  republishes automatically when this merges to `main`.
- This PR establishes the process itself (maintainer change); the issue-first requirement
  applies to contributions going forward.
