### PR TITLE
v1.2.2 — English-language enforcement (OS + AD prerequisites) (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-07-31
+
+### Added
+- **English-language enforcement (#23)**: `Test-TierModelPrerequisites` now fails fast — before any deployment or audit change — when the environment is not English (`en-US`). Two unconditional checks run up front and are inherited by both `Deploy-TierModel.ps1` and `Audit-TierModel.ps1`:
+  - **Host operating system** — reads the local machine's static `InstallLanguage` LCID (`HKLM\SYSTEM\CurrentControlSet\Control\Nls\Language`) and requires an English variant (primary language `0x09`, e.g. en-US/en-GB). Runs after the elevation check and **before** the Pester/module checks, and returns immediately on a non-English host so the operator is never asked to install modules on an unsupported OS.
+  - **Active Directory** — resolves three well-known groups by SID (Domain Admins `<DomainSID>-512`, Server Operators `S-1-5-32-549`, Account Operators `S-1-5-32-548`) and requires each directory `Name` to be its English value. Child-domain safe (no Enterprise/Schema Admins); names are read from AD (never client-side SID translation, which the local OS would localize into a false pass). A confirmed localized name always fails closed even if another well-known group cannot be resolved.
+  - Both checks emit friendly `Errors`/`Remediation` and record diagnostics in `EnvironmentSnapshot` (`HostInstallLanguage`, `HostOsEnglish`, `AdLanguageEnglish`, `AdLanguageMismatches`, …).
+- **Documentation**: new `docs/language-support.md` documenting the English-only requirement, the 18 fully-localized Windows Server languages that are detected and stopped, and a future community-localization roadmap. Prerequisite notes added to the README, the quick/detailed deployment guides, and the FAQ.
+
+### Notes
+- No configuration changes are required and English (`en-US`) deployments and audits are unaffected (full suite: **1,435** automated tests passing; module scope ~91% coverage). Non-English environments are a documented, unsupported scenario — see `docs/language-support.md`.
+
 ## [1.2.1] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,23 +39,24 @@ To get started with TierModel, please refer to our comprehensive documentation:
 
 ## 🧪 Testing & Quality Assurance
 
-**Current Test Status: ✅ ALL TESTS PASSING** *(Last run: July 30, 2026)*
+**Current Test Status: ✅ ALL TESTS PASSING** *(Last run: July 31, 2026)*
 
 | Test Suite | Test Files | Test Cases | Status | Coverage |
 |------------|-----------|------------|--------|----------|
-| **Unit Tests** | 17 files | 1,137 tests | ✅ 100% Pass | **88.68%** |
+| **Unit Tests** | 17 files | 1,147 tests | ✅ 100% Pass | **88.72%** |
 | **Integration Tests** | 7 files | 288 tests | ✅ 100% Pass | **100%** |
 | **Manual Integration Tests** | 1 file | 331 tests | ✅ 100% Pass | **100%** |
-| **Total** | **25 files** | **1,756 tests** | ✅ **All Passing** | **88.68%** |
+| **Total** | **25 files** | **1,766 tests** | ✅ **All Passing** | **88.72%** |
 
 ### Test Coverage Highlights
 - ✅ **63/63** production files have comprehensive test coverage (5 new Windows LAPS cmdlets added in v1.2.0)
-- ✅ **100%** of all automated 1,425 test cases passing
+- ✅ **100%** of all automated 1,435 test cases passing
 - ✅ **100%** of all manual 331 test cases passing
-- ✅ **88.68%** overall docs-scope line coverage — `modules/TierModel/*` module scope ~91% (all above 80% CI gate); `Audit-TierModel.ps1` at 73.1% (new fail-fast/alignment paths need live-AD or PS<7 to exercise), `Deploy-TierModel.ps1` at 81.4%
+- ✅ **88.72%** overall docs-scope line coverage — `modules/TierModel/*` module scope ~91% (all above 80% CI gate); `Audit-TierModel.ps1` at 73.1% (new fail-fast/alignment paths need live-AD or PS<7 to exercise), `Deploy-TierModel.ps1` at 81.4%
 - ✅ `Get-TierModelConditionalGroupNames` — new function with full test coverage (6 unit tests)
 - ✅ **New in v1.2.0:** Unit and integration test files for Windows LAPS (Unit.WinLapsAclOperations.Tests.ps1, Integration.WinLapsDeployment.Tests.ps1)
 - ✅ **New in v1.2.1:** UI & reliability bug fixes (BUG-001..011) — see CHANGELOG.
+- ✅ **New in v1.2.2:** English-language enforcement (#23) — fail-fast host-OS and Active Directory (en-US only) prerequisite checks (10 new unit tests); see [Language Support](https://microsoft.github.io/ActiveDirectoryTierModel/language-support/).
 - ✅ Mock-based testing (no Active Directory connectivity required)
 - ✅ WhatIf support validation across all deployment operations
 
@@ -152,7 +153,7 @@ cd ActiveDirectoryTierModel
 
 ---
 
-**Version**: 1.2.1 | **License**: MIT | **Status**: ✅ Production Ready
+**Version**: 1.2.2 | **License**: MIT | **Status**: ✅ Production Ready
 
 ## 🚀 Releasing
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To get started with TierModel, please refer to our comprehensive documentation:
 - **[CI/CD Integration](https://microsoft.github.io/ActiveDirectoryTierModel/ci-cd/)** - Pipeline integration and automation
 - **[Test Tag Matrix](https://microsoft.github.io/ActiveDirectoryTierModel/test-tag-matrix/)** - Pester test organization
 - **[Test Coverage](https://microsoft.github.io/ActiveDirectoryTierModel/test-coverage/)** - Comprehensive test coverage analysis and roadmap
+- **[Language Support](https://microsoft.github.io/ActiveDirectoryTierModel/language-support/)** - Supported languages (English only today) and the localization roadmap
 
 ### 🔧 Technical Specifications
 - **[Feature Specification](specs/001-tier-model-module/spec.md)** - Complete requirements and user stories
@@ -138,6 +139,7 @@ cd ActiveDirectoryTierModel
 - **Elevation**: Administrator privileges required
 - **Domain Admin**: Membership in Domain Admins group
 - **Modules**: ActiveDirectory, GroupPolicy (see `config/dependencies.json`)
+- **Language**: English (`en-US`) only — both the domain controller **OS** and **Active Directory** must be English (see [Language Support](https://microsoft.github.io/ActiveDirectoryTierModel/language-support/))
 
 *For detailed prerequisite validation, run `Test-TierModelPrerequisites`*
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cd ActiveDirectoryTierModel
 - **Elevation**: Administrator privileges required
 - **Domain Admin**: Membership in Domain Admins group
 - **Modules**: ActiveDirectory, GroupPolicy (see `config/dependencies.json`)
-- **Language**: English (`en-US`) only — both the domain controller **OS** and **Active Directory** must be English (see [Language Support](https://microsoft.github.io/ActiveDirectoryTierModel/language-support/))
+- **Language**: English (`en-US`) only — both the **host OS** (the machine you run the scripts from) and **Active Directory** must be English (see [Language Support](https://microsoft.github.io/ActiveDirectoryTierModel/language-support/))
 
 *For detailed prerequisite validation, run `Test-TierModelPrerequisites`*
 

--- a/docs/detailed-deployment-guide.md
+++ b/docs/detailed-deployment-guide.md
@@ -4,7 +4,7 @@ This guide provides a step-by-step deployment workflow using scoped deployment p
 
 For a streamlined full deployment workflow, see the [Quick Deployment Guide](quick-deployment-guide.md).
 
-> **Supported environment:** English (`en-US`) only — the domain controller **OS** and **Active Directory** must both be English. Non-English environments are detected and stopped during prerequisite validation. See [Language Support](language-support.md).
+> **Supported environment:** English (`en-US`) only — the **host OS** (the machine you run the scripts from) and **Active Directory** must both be English. Non-English environments are detected and stopped during prerequisite validation. See [Language Support](language-support.md).
 
 ## Overview
 

--- a/docs/detailed-deployment-guide.md
+++ b/docs/detailed-deployment-guide.md
@@ -4,6 +4,8 @@ This guide provides a step-by-step deployment workflow using scoped deployment p
 
 For a streamlined full deployment workflow, see the [Quick Deployment Guide](quick-deployment-guide.md).
 
+> **Supported environment:** English (`en-US`) only — the domain controller **OS** and **Active Directory** must both be English. Non-English environments are detected and stopped during prerequisite validation. See [Language Support](language-support.md).
+
 ## Overview
 
 This detailed approach deploys Tier Model components one type at a time, following the proper dependency order:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -108,8 +108,8 @@ The high-level migration path is:
 - Scoped deployments (e.g., `-OuAclsOnly`) may work with delegated permissions — to be confirmed per use case
 
 ### What language or locale is supported?
-- **English (`en-US`) only, at this time.** Both the domain controller's **operating system** and **Active Directory** must be English.
-- The tool runs **two fail-fast prerequisite checks** — one for the domain controller's OS install language, one for the well-known Active Directory group names — and stops with a clear message on a non-English environment **before making any change**.
+- **English (`en-US`) only, at this time.** Both the **host** you run the scripts from (your workstation or the domain controller) and **Active Directory** must be English.
+- The tool runs **two fail-fast prerequisite checks** — one for the host OS install language, one for the well-known Active Directory group names — and stops with a clear message on a non-English environment **before making any change**.
 - Only 18 languages fully localize Windows Server (including AD group names); English is supported and the other 17 are detected and stopped. Language Interface Packs (e.g. Hindi, Bengali) and non-bold language packs (e.g. Arabic) keep English AD names and are unaffected.
 - See [Language Support](language-support.md) for the full language list and the future localization roadmap.
 
@@ -330,7 +330,7 @@ The time and energy spent trying to minimize the Tier Model footprint would be f
 - Confirm you are running as Domain Admin
 - Confirm network connectivity to the `-PreferredDc` specified
 - Check that all required modules are installed at the correct versions
-- Confirm the domain controller **OS** and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
+- Confirm the **host OS** (where you run the scripts) and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
 
 ### An OU was not created. Why?
 - The OU may already exist (check the log for "OU already exists" INFO messages)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -107,6 +107,12 @@ The high-level migration path is:
 - **Domain Admin** membership is required for full deployment
 - Scoped deployments (e.g., `-OuAclsOnly`) may work with delegated permissions — to be confirmed per use case
 
+### What language or locale is supported?
+- **English (`en-US`) only, at this time.** Both the domain controller's **operating system** and **Active Directory** must be English.
+- The tool runs **two fail-fast prerequisite checks** — one for the domain controller's OS install language, one for the well-known Active Directory group names — and stops with a clear message on a non-English environment **before making any change**.
+- Only 18 languages fully localize Windows Server (including AD group names); English is supported and the other 17 are detected and stopped. Language Interface Packs (e.g. Hindi, Bengali) and non-bold language packs (e.g. Arabic) keep English AD names and are unaffected.
+- See [Language Support](language-support.md) for the full language list and the future localization roadmap.
+
 ### What PowerShell modules must be installed?
 - `ActiveDirectory` (v1.0.1.0 or later)
 - `GroupPolicy` (v1.0 or later)
@@ -324,6 +330,7 @@ The time and energy spent trying to minimize the Tier Model footprint would be f
 - Confirm you are running as Domain Admin
 - Confirm network connectivity to the `-PreferredDc` specified
 - Check that all required modules are installed at the correct versions
+- Confirm the domain controller **OS** and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
 
 ### An OU was not created. Why?
 - The OU may already exist (check the log for "OU already exists" INFO messages)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,7 @@ Welcome to the Active Directory Tier Model documentation.
 - **[Test Tag Matrix](test-tag-matrix.md)** - Test organization, tagging, and execution strategies
 - **[Test Coverage](test-coverage.md)** - Comprehensive test coverage analysis and roadmap
 - **[CI/CD Integration](ci-cd.md)** - Continuous Integration and Deployment pipelines
+
+## Reference
+
+- **[Language Support](language-support.md)** - Supported languages (English only today), the 18 fully-localized Windows Server languages, and the roadmap and challenges for community localization

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,9 +1,9 @@
 # Language Support
 
 > **Status: English (`en-US`) only.** At this time the Active Directory Tier Model
-> supports deploying and auditing only where **both** the domain controller's operating
-> system **and** Active Directory are English. On a non-English domain controller OS or
-> a localized Active Directory, `Deploy-TierModel` and `Audit-TierModel` **stop during
+> supports deploying and auditing only where **both** the host operating system (the
+> machine you run the scripts from) **and** Active Directory are English. On a non-English
+> host OS or a localized Active Directory, `Deploy-TierModel` and `Audit-TierModel` **stop during
 > prerequisite validation** with a clear message rather than partially applying an
 > inconsistent configuration.
 
@@ -38,8 +38,9 @@ Detecting the **domain's** language must be done at the Active Directory level: 
 or registry install language can disagree with the domain — for example, an English-OS
 domain controller joined to a German domain still serves German names — so an OS check
 alone cannot stand in for the directory check. In addition, the Tier Model requires the
-domain controller's **operating system** to be installed in English, so that English is
-guaranteed in *both* places: the OS **and** the directory.
+**operating system of the host you run the scripts from** (your admin workstation or the
+domain controller itself) to be installed in English, so that English is guaranteed in
+*both* places: the host OS **and** the directory.
 
 ## How the requirement is enforced
 
@@ -48,12 +49,13 @@ that both `Deploy-TierModel` and `Audit-TierModel` run up front — before any c
 made. Both must pass; if either fails, the run stops with a friendly, actionable error.
 In the final code the checks run in this order:
 
-### Check 1 — English operating system (domain controller)
+### Check 1 — English operating system (execution host)
 
-The target domain controller's Windows **installation language** must be English
-(`en-US` — install language `0409`). This is the static, authoritative signal for how
-the operating system was installed, and it is read from the domain controller itself.
-This check runs **first** because it is the broadest, cheapest signal.
+The Windows **installation language** of the host where you run `Deploy-TierModel` /
+`Audit-TierModel` — your admin workstation or the domain controller itself — must be
+English (`en-US` — install language `0409`). It is read from the local machine running
+the scripts. This check runs **first**; if the host OS is not English, the run stops
+before the Active Directory check.
 
 ### Check 2 — English Active Directory (well-known group names)
 
@@ -86,11 +88,12 @@ Design notes:
 
 Neither check alone is sufficient:
 
-- **OS check alone** would miss an English-OS domain controller joined to a localized
-  domain — the directory names are still localized (Check 2 catches this).
-- **AD check alone** would allow a non-English domain controller OS, which the Tier
-  Model does not support and which can affect locale-sensitive OS-level operations even
-  when the directory names happen to be English.
+- **OS check alone** would still allow a **localized directory** — you could run from an
+  English host against a non-English domain, where the well-known names differ (Check 2
+  catches this).
+- **AD check alone** would allow running from a **non-English host**, which the Tier
+  Model does not support and which can affect locale-sensitive host-side operations
+  (e.g. ADML template locale, string/date handling) even when the directory is English.
 
 Requiring **both** guarantees English end-to-end — in the operating system and in the
 directory. Each check has its own dedicated fail-fast test.

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,0 +1,217 @@
+# Language Support
+
+> **Status: English (`en-US`) only.** At this time the Active Directory Tier Model
+> supports deploying and auditing only where **both** the domain controller's operating
+> system **and** Active Directory are English. On a non-English domain controller OS or
+> a localized Active Directory, `Deploy-TierModel` and `Audit-TierModel` **stop during
+> prerequisite validation** with a clear message rather than partially applying an
+> inconsistent configuration.
+
+This page explains *why* only English is supported today, *how* that requirement is
+enforced, the complete set of languages it affects, and what it would take for the
+community to bring the Tier Model to the remaining languages in the future.
+
+## Why English only?
+
+Active Directory stores the **names** of its well-known security principals — for
+example *Domain Admins*, *Server Operators*, and *Account Operators* — as real
+directory attributes. Those names are **localized once, at domain creation**, from
+the installation language of the first domain controller, and then replicated to
+every domain controller in the domain/forest.
+
+Two consequences matter here:
+
+1. **The domain's language is fixed and independent of the machine you run from.**
+   Opening *Active Directory Users and Computers* (`dsa.msc`) from an English
+   Windows 11 client against a German domain still shows `Domänen-Admins`, not
+   `Domain Admins` — the name comes from the directory, not the client. A domain
+   controller later installed with an **English** OS and joined to that German
+   domain still serves the **German** names, because they are replicated, not
+   recreated.
+2. **The Tier Model references well-known principals by their English names.** The
+   configuration set refers to these names in hundreds of places — the
+   restricted-groups and user-rights entries in `config/tiermodel-gpos.json` alone
+   contain **389** such references. On a localized domain those lookups do not
+   resolve, which would cause partial or failed deployments.
+
+Detecting the **domain's** language must be done at the Active Directory level: the OS
+or registry install language can disagree with the domain — for example, an English-OS
+domain controller joined to a German domain still serves German names — so an OS check
+alone cannot stand in for the directory check. In addition, the Tier Model requires the
+domain controller's **operating system** to be installed in English, so that English is
+guaranteed in *both* places: the OS **and** the directory.
+
+## How the requirement is enforced
+
+`Test-TierModelPrerequisites` performs **two unconditional, fail-fast language checks**
+that both `Deploy-TierModel` and `Audit-TierModel` run up front — before any change is
+made. Both must pass; if either fails, the run stops with a friendly, actionable error.
+In the final code the checks run in this order:
+
+### Check 1 — English operating system (domain controller)
+
+The target domain controller's Windows **installation language** must be English
+(`en-US` — install language `0409`). This is the static, authoritative signal for how
+the operating system was installed, and it is read from the domain controller itself.
+This check runs **first** because it is the broadest, cheapest signal.
+
+### Check 2 — English Active Directory (well-known group names)
+
+The domain's well-known group **names** must be English. The check resolves three
+well-known groups **by SID** and compares each group's directory `Name` to its expected
+English value:
+
+| Canary group | SID / RID | Scope |
+|--------------|-----------|-------|
+| Domain Admins | `<DomainSID>-512` | Domain — exists in every domain |
+| Server Operators | `S-1-5-32-549` | BUILTIN — exists in every domain |
+| Account Operators | `S-1-5-32-548` | BUILTIN — exists in every domain |
+
+Design notes:
+
+- **All three must equal their English names to pass.** If **any** of the three
+  differs, the domain is treated as non-English and the run stops with a friendly
+  error that names the group and the localized value that was found.
+- **Three groups, not one** — defense in depth against an administrator having
+  renamed a single built-in group, or an unusual language that leaves one name
+  coincidentally matching English.
+- **Domain and BUILTIN groups only** (no *Enterprise Admins* / *Schema Admins*), so
+  the check is correct when deploying into a **child domain**; forest-root-only
+  groups are intentionally avoided.
+- The name is read **from Active Directory** (`Get-ADGroup -Identity <SID>`), not via
+  a client-side SID-to-name translation, because BUILTIN SID translation is localized
+  by the *client* OS and would produce a false pass.
+
+### Why both checks?
+
+Neither check alone is sufficient:
+
+- **OS check alone** would miss an English-OS domain controller joined to a localized
+  domain — the directory names are still localized (Check 2 catches this).
+- **AD check alone** would allow a non-English domain controller OS, which the Tier
+  Model does not support and which can affect locale-sensitive OS-level operations even
+  when the directory names happen to be English.
+
+Requiring **both** guarantees English end-to-end — in the operating system and in the
+directory. Each check has its own dedicated fail-fast test.
+
+## Supported vs. unsupported languages
+
+Microsoft fully localizes the Windows **Server** user interface — including Active
+Directory built-in group names — for **only 18 languages**. As the
+[Available Language Packs for Windows](https://learn.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows)
+reference states: *"In Windows Server 2012 and later the user interface (UI) is
+localized only for the 18 languages listed in bold."*
+
+English is one of those 18. The **other 17 are therefore the complete set of
+languages that would trip the gate** — there is no fully-localized Windows Server
+language outside this list, so the matrix below is exhaustive.
+
+| #  | Language (`locale`)              | Domain Admins               | Server Operators        | Account Operators             | Result       |
+|----|----------------------------------|-----------------------------|-------------------------|-------------------------------|--------------|
+| 1  | English (`en-US`)                | Domain Admins               | Server Operators        | Account Operators             | ✅ Supported |
+| 2  | Chinese – Simplified (`zh-CN`)   | 域管理员                    | 服务器操作员            | 帐户操作员                    | 🛑 Stops     |
+| 3  | Chinese – Traditional (`zh-TW`)  | 網域系統管理員              | 伺服器操作員            | 帳戶操作員                    | 🛑 Stops     |
+| 4  | Czech (`cs-CZ`)                  | Správci domény              | Operátoři serveru       | Operátoři účtů                | 🛑 Stops     |
+| 5  | Dutch (`nl-NL`)                  | Domeinadmins                | Serveroperators         | Accountoperators              | 🛑 Stops     |
+| 6  | French (`fr-FR`)                 | Admins du domaine           | Opérateurs de serveur   | Opérateurs de compte          | 🛑 Stops     |
+| 7  | German (`de-DE`)                 | Domänen-Admins              | Server-Operatoren       | Konten-Operatoren             | 🛑 Stops     |
+| 8  | Hungarian (`hu-HU`)              | Tartománygazdák             | Kiszolgálókezelők       | Fiókkezelők                   | 🛑 Stops     |
+| 9  | Italian (`it-IT`)                | Amministratori di dominio   | Operatori server        | Operatori account             | 🛑 Stops     |
+| 10 | Japanese (`ja-JP`)               | ドメイン管理者              | サーバー オペレーター   | アカウント オペレーター       | 🛑 Stops     |
+| 11 | Korean (`ko-KR`)                 | 도메인 관리자               | 서버 운영자             | 계정 운영자                   | 🛑 Stops     |
+| 12 | Polish (`pl-PL`)                 | Administratorzy domeny      | Operatorzy serwera      | Operatorzy kont               | 🛑 Stops     |
+| 13 | Portuguese – Brazil (`pt-BR`)    | Administradores de domínio  | Operadores de servidor  | Operadores de contas          | 🛑 Stops     |
+| 14 | Portuguese – Portugal (`pt-PT`)  | Administradores de Domínio  | Operadores de Servidor  | Operadores de Conta           | 🛑 Stops     |
+| 15 | Russian (`ru-RU`)                | Администраторы домена       | Операторы сервера       | Операторы учетных записей     | 🛑 Stops     |
+| 16 | Spanish (`es-ES`)                | Administradores de dominio  | Operadores de servidor  | Operadores de cuentas         | 🛑 Stops     |
+| 17 | Swedish (`sv-SE`)                | Domänadministratörer        | Serveroperatörer        | Kontooperatörer               | 🛑 Stops     |
+| 18 | Turkish (`tr-TR`)                | Etki Alanı Yöneticileri     | Sunucu İşletmenleri     | Hesap İşletmenleri            | 🛑 Stops     |
+
+> The non-English names above are illustrative, drawn from localized Windows
+> references (German is confirmed against Microsoft Learn). Exact spelling is
+> irrelevant to enforcement: the gate only ever compares against the **English**
+> names, and every fully-localized language localizes these built-in names as a set,
+> so any of the 17 will differ from English and stop.
+
+### What about other languages?
+
+Any language **not** in the 18 above keeps **English** Active Directory names and is
+therefore **supported today**:
+
+- **Language Interface Packs (LIPs)** — e.g. Hindi, Bengali, Urdu, Indonesian — are
+  partial translations layered on an English base. They do **not** localize AD
+  built-in group names, so those installs remain effectively English.
+- **Non-bold full Language Packs** — e.g. Arabic, Greek, Hebrew, Danish, Finnish,
+  Norwegian, Thai — ship a language pack, but the Windows **Server** UI (and the AD
+  names) is not fully localized, so those names also remain English.
+
+In other words, the gate's pass/stop boundary lines up exactly with the set of
+domains that would actually break — no more, no less.
+
+## What it would take to support another language
+
+Adding a language is not a code change; it is a **content and validation** effort:
+
+- **Localized configuration files** for every config that names a principal or
+  object — for example `config/tiermodel-groups.json`, `config/tiermodel-gpos.json`
+  (hundreds of references), `config/tiermodel-acls.json`, `config/tiermodel-users.json`,
+  and `config/tiermodel-winlaps.json`.
+- **Correct localized names** for every well-known principal the model touches, plus
+  any localized container or OU path.
+- **Full functional and integration regression** for that language, on a domain
+  actually installed in it.
+
+## A possible future model: community language packs
+
+A natural future design is a `-Language <locale>` parameter that selects a
+language-specific configuration set:
+
+- The **English** configuration remains the canonical, reference implementation.
+- The community **contributes and maintains** the configuration files for each
+  additional language.
+- Each contributed language requires the contributor to complete **full manual
+  regression** using the manual integration workbook (`manual.integration.tests.xlsx`)
+  against a domain installed in that language, in addition to the automated tests.
+
+## Challenges and trade-offs
+
+Broad language support has a real, ongoing cost that grows with the project:
+
+- **Release velocity.** Every new feature would have to be implemented **and
+  regression-tested across all supported languages** before it could ship. A single
+  change becomes an *N*-language change — lots of moving parts, and a much larger
+  test matrix on every release.
+- **Maintenance burden.** Localized config drifts as features evolve; keeping 17
+  additional language sets correct is a continuous commitment, not a one-time port.
+- **Contributor coordination.** Each language needs an owner willing to run and
+  re-run the manual regression as the product changes.
+
+For these reasons, the pragmatic sequencing is to pursue localization **only once the
+Tier Model is a near-complete solution** — i.e. no major features still need to be
+added. At that point the per-feature multiplier no longer applies to a moving target,
+and the effort becomes a bounded, community-drivable project rather than a permanent
+tax on every release.
+
+## Historical context and opportunity
+
+The internal, **closed-source** Microsoft Tier Model tooling — used for roughly a
+decade — also supported **English only**. Language coverage has therefore never been
+part of the Tier Model, even in its private form.
+
+Now that an **official, open-source** Microsoft Tier Model exists, the community has,
+for the first time, a realistic path to collaboratively extend the model to the
+remaining 17 fully-localized languages. This document captures the groundwork — the
+exhaustive language list and the detection design — so that effort can start from a
+known, verified baseline whenever the project is ready.
+
+## References
+
+- [Available Language Packs for Windows](https://learn.microsoft.com/windows-hardware/manufacture/desktop/available-language-packs-for-windows)
+  — the statement that Windows Server localizes its UI for only the 18 bold languages.
+- [Understand security groups (Active Directory)](https://learn.microsoft.com/windows-server/identity/ad-ds/manage/understand-security-groups)
+  — the default/built-in groups and their well-known RIDs.
+- [Security identifiers (well-known SIDs)](https://learn.microsoft.com/windows-server/identity/ad-ds/manage/understand-security-identifiers)
+  — why SID/RID resolution is language-independent.
+- [Issue #23 — Language DC Error](https://github.com/microsoft/ActiveDirectoryTierModel/issues/23)
+  — the original report that motivated this requirement.

--- a/docs/quick-deployment-guide.md
+++ b/docs/quick-deployment-guide.md
@@ -10,7 +10,7 @@ Before deploying the Tier Model, ensure the following requirements are met:
 - **PowerShell 7.0 or later** (PowerShell 5.1 is not supported)
 - **Domain Admin membership** for deployment operations
 - **Network access** to your preferred Domain Controller
-- **English (`en-US`) only** — the domain controller **OS** and **Active Directory** must both be English; non-English environments are detected and stopped up front (see [Language Support](language-support.md))
+- **English (`en-US`) only** — the **host OS** (the machine you run the scripts from) and **Active Directory** must both be English; non-English environments are detected and stopped up front (see [Language Support](language-support.md))
 
 ### Required PowerShell Modules
 - `ActiveDirectory` (version 1.0.1.0 or later)
@@ -124,7 +124,7 @@ If `Test-TierModelPrerequisites` reports errors:
 - Install PowerShell 7+ from https://github.com/PowerShell/PowerShell/releases
 - Verify Domain Admin group membership
 - Ensure required AD and GP modules are installed (use RSAT on Windows)
-- Ensure the domain controller **OS** and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
+- Ensure the **host OS** (where you run the scripts) and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
 
 ### Deployment Errors
 - Review error messages in deployment output

--- a/docs/quick-deployment-guide.md
+++ b/docs/quick-deployment-guide.md
@@ -10,6 +10,7 @@ Before deploying the Tier Model, ensure the following requirements are met:
 - **PowerShell 7.0 or later** (PowerShell 5.1 is not supported)
 - **Domain Admin membership** for deployment operations
 - **Network access** to your preferred Domain Controller
+- **English (`en-US`) only** — the domain controller **OS** and **Active Directory** must both be English; non-English environments are detected and stopped up front (see [Language Support](language-support.md))
 
 ### Required PowerShell Modules
 - `ActiveDirectory` (version 1.0.1.0 or later)
@@ -123,6 +124,7 @@ If `Test-TierModelPrerequisites` reports errors:
 - Install PowerShell 7+ from https://github.com/PowerShell/PowerShell/releases
 - Verify Domain Admin group membership
 - Ensure required AD and GP modules are installed (use RSAT on Windows)
+- Ensure the domain controller **OS** and **Active Directory** are English (`en-US`) — non-English environments are not supported (see [Language Support](language-support.md))
 
 ### Deployment Errors
 - Review error messages in deployment output

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -9,7 +9,9 @@
 
 > **How coverage is measured:** Pester v5's built-in `CodeCoverage` feature instruments each production file and tracks which lines are executed during the full test suite run (`Invoke-AllTests.ps1`). To re-run: `cd TierModel; $c = New-PesterConfiguration; $c.Run.Path = './tests'; $c.CodeCoverage.Enabled = $true; $c.CodeCoverage.Path = @('./modules/TierModel/public/*.ps1','./modules/TierModel/TierModel.psm1','./Audit-TierModel.ps1','./Deploy-TierModel.ps1'); Invoke-Pester -Configuration $c`
 
-**Last measured:** July 30, 2026 (1,425 tests / 0 failed — v1.2.1 UI & bug fixes) | **Overall: 88.68%** | **Target: 95%**
+**Last measured:** July 31, 2026 (1,435 tests / 0 failed — v1.2.2 English-language enforcement) | **Overall: 88.72%** | **Target: 95%**
+
+> ✅ **v1.2.2 measured:** English-language enforcement (#23) added two fail-fast checks (host OS + Active Directory) to `Test-TierModelPrerequisites.ps1` with 10 new unit tests; the file's new code is fully covered (file 82.7% → 84.62%). English (en-US) deployment/audit behavior is unchanged; overall docs-scope coverage held at 88.72%.
 
 > ✅ **v1.2.0 measured:** 5 new Windows LAPS cmdlets added with comprehensive test coverage. New files span 81.6–92.7%. 2 new test files: Unit.WinLapsAclOperations.Tests.ps1, Integration.WinLapsDeployment.Tests.ps1.
 
@@ -32,7 +34,7 @@
 | `modules/TierModel/public/Import-TierModelGpo.ps1` | 89 | 21 | 110 | 🟠 80.9% ✦ |
 | `Deploy-TierModel.ps1` | 1765 | 403 | 2168 | 🟠 81.4% ✦ |
 | `modules/TierModel/public/Get-TierModelWinLapsAcl.ps1` | — | — | 543 | 🟠 81.6% |
-| `modules/TierModel/public/Test-TierModelPrerequisites.ps1` | 343 | 72 | 415 | 🟠 82.7% ✦ |
+| `modules/TierModel/public/Test-TierModelPrerequisites.ps1` | 396 | 72 | 468 | 🟠 84.62% ✦ |
 | `modules/TierModel/TierModel.psm1` | 582 | 121 | 703 | 🟠 82.8% ✦ |
 | `modules/TierModel/public/New-TierModelGptTmplContent.ps1` | 85 | 17 | 102 | 🟠 83.3% |
 | `modules/TierModel/public/Get-TierModelWinLapsAclFd.ps1` | 383 | 76 | 459 | 🟠 83.4% |
@@ -159,7 +161,7 @@
 | `Import-TierModelGpo.ps1` | 89 | 21 | 110 | 80.9% ✦ |
 | `Deploy-TierModel.ps1` | 1765 | 403 | 2168 | 81.4% ✦ |
 | `TierModel.psm1` | 582 | 121 | 703 | 82.8% ✦ |
-| `Test-TierModelPrerequisites.ps1` | 343 | 72 | 415 | 82.7% ✦ |
+| `Test-TierModelPrerequisites.ps1` | 396 | 72 | 468 | 84.62% ✦ |
 | `New-TierModelGptTmplContent.ps1` | 85 | 17 | 102 | 83.3% |
 | `Update-TierModelGPOConfig.ps1` | 87 | 17 | 104 | 83.7% |
 | `Get-TierModelUserFd.ps1` | 83 | 15 | 98 | 84.7% |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,3 +21,4 @@ nav:
   - Test Tag Matrix: test-tag-matrix.md
   - Tier Model Logging: tiermodel-logging.md
   - Test Coverage: test-coverage.md
+  - Language Support: language-support.md

--- a/modules/TierModel/TierModel.psd1
+++ b/modules/TierModel/TierModel.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'TierModel.psm1'
-    ModuleVersion = '1.2.1'
+    ModuleVersion = '1.2.2'
     GUID = 'b6a7c9f8-5e5d-4c7a-9b9e-2e2e9a4f6d10'
     Author = 'TierModel Team'
     CompanyName = 'Enterprise AD'
@@ -79,7 +79,7 @@
     PrivateData = @{ 
         PSData = @{
             Tags = @('ActiveDirectory', 'TierModel', 'Security', 'GPO', 'ADMX', 'Deployment', 'Audit')
-            ReleaseNotes = '1.2.1: UI and reliability bug fixes (BUG-001..011) — preferred-DC ACL binds, aligned fail-fast prerequisite messages, WinLaps UnexpectedAcl + GenericAll exclusion, verified/retried OU inheritance, phantom-skip count fix. See CHANGELOG. 1.2.0: Added Windows LAPS deployment and audit cmdlets (-IncludeWinLaps). 1.1.0: Added Managed Service Account (MSA/gMSA/dMSA) ACL deployment and audit cmdlets. 1.0.0: Segmented JSON config, fail-fast validation, correlation ID logging, ADMX import'
+            ReleaseNotes = '1.2.2: English-language enforcement (#23) — fail-fast host-OS and Active Directory (en-US only) language checks in Test-TierModelPrerequisites, plus docs/language-support.md. 1.2.1: UI and reliability bug fixes (BUG-001..011) — preferred-DC ACL binds, aligned fail-fast prerequisite messages, WinLaps UnexpectedAcl + GenericAll exclusion, verified/retried OU inheritance, phantom-skip count fix. See CHANGELOG. 1.2.0: Added Windows LAPS deployment and audit cmdlets (-IncludeWinLaps). 1.1.0: Added Managed Service Account (MSA/gMSA/dMSA) ACL deployment and audit cmdlets. 1.0.0: Segmented JSON config, fail-fast validation, correlation ID logging, ADMX import'
         }
     }
 }

--- a/modules/TierModel/public/Test-TierModelPrerequisites.ps1
+++ b/modules/TierModel/public/Test-TierModelPrerequisites.ps1
@@ -134,7 +134,40 @@ function Test-TierModelPrerequisites {
             $null = $result.Errors.Add("PowerShell session is not running as Administrator.")
             $null = $result.Remediation.Add("Start PowerShell as Administrator (Run as administrator)")
         }
-        
+
+        # --- English-language host operating system check (unconditional) ---
+        # The Tier Model supports English (en-US) Windows only. Verify the OS of the host
+        # running this script (admin workstation OR domain controller) was installed in
+        # English by reading the static InstallLanguage LCID from
+        # HKLM\SYSTEM\CurrentControlSet\Control\Nls\Language. Any English variant passes
+        # (primary language 0x09 — en-US, en-GB, ...); the AD group-name check further below
+        # is the authoritative directory-language gate. This runs before the Pester/module
+        # checks so a non-English host stops immediately — there is no reason to have the
+        # operator install modules on an unsupported OS. Guarded: if the language cannot be
+        # read, record it and continue. See docs/language-support.md.
+        try {
+            $hostInstallLanguage = Get-ItemPropertyValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\Language' -Name 'InstallLanguage' -ErrorAction Stop
+            $result.EnvironmentSnapshot.HostInstallLanguage = $hostInstallLanguage
+            $hostPrimaryLanguage = ([Convert]::ToInt32([string]$hostInstallLanguage, 16)) -band 0x3FF
+            $hostOsEnglish = ($hostPrimaryLanguage -eq 0x09)
+            $result.EnvironmentSnapshot.HostOsEnglish = $hostOsEnglish
+            if (-not $hostOsEnglish) {
+                $result.Valid = $false
+                $null = $result.Errors.Add("Non-English host operating system detected. The Tier Model supports English (en-US) Windows only.")
+                $null = $result.Remediation.Add("Run Deploy and Audit from an English (en-US) Windows host. See Language Support: https://microsoft.github.io/ActiveDirectoryTierModel/language-support/")
+                # Fail fast: stop before the module/domain/AD checks on an unsupported OS.
+                $result.Errors = @($result.Errors)
+                $result.Remediation = @($result.Remediation)
+                Write-Output $result
+                return
+            }
+        }
+        catch {
+            # Could not determine the host install language (e.g. registry value absent).
+            # Do not hard-block on the OS signal; the AD language check still applies.
+            $result.EnvironmentSnapshot.HostOsLanguageCheckError = $_.Exception.Message
+        }
+
         # Test required modules and versions (dependencies already parsed at start)
         # Check Pester version. Any Pester 5.x release is supported; Pester 6.x introduces
         # breaking changes (new mock engine / Should-* assertions) that are not yet tested,

--- a/modules/TierModel/public/Test-TierModelPrerequisites.ps1
+++ b/modules/TierModel/public/Test-TierModelPrerequisites.ps1
@@ -439,10 +439,21 @@ function Test-TierModelPrerequisites {
                     )
 
                     $languageMismatches = [System.Collections.ArrayList]@()
+                    $resolvedAnyCanary = $false
                     foreach ($canary in $englishCanaries) {
-                        $grp = Get-ADGroup -Identity $canary.Sid -Server $PreferredDc -ErrorAction Stop
-                        if ($null -ne $grp -and -not [string]::IsNullOrEmpty($grp.Name) -and $grp.Name -ne $canary.Expected) {
-                            $null = $languageMismatches.Add("$($canary.Expected) is named '$($grp.Name)'")
+                        try {
+                            $grp = Get-ADGroup -Identity $canary.Sid -Server $PreferredDc -ErrorAction Stop
+                        }
+                        catch {
+                            # A single well-known group could not be resolved; skip it so a
+                            # transient failure cannot mask a confirmed mismatch on another.
+                            continue
+                        }
+                        if ($null -ne $grp -and -not [string]::IsNullOrEmpty($grp.Name)) {
+                            $resolvedAnyCanary = $true
+                            if ($grp.Name -ne $canary.Expected) {
+                                $null = $languageMismatches.Add("$($canary.Expected) is named '$($grp.Name)'")
+                            }
                         }
                     }
 
@@ -453,7 +464,7 @@ function Test-TierModelPrerequisites {
                         $null = $result.Errors.Add("Non-English Active Directory detected. The Tier Model supports English (en-US) Active Directory only.")
                         $null = $result.Remediation.Add("Run Deploy and Audit against an English (en-US) Active Directory. See Language Support: https://microsoft.github.io/ActiveDirectoryTierModel/language-support/")
                     }
-                    else {
+                    elseif ($resolvedAnyCanary) {
                         $result.EnvironmentSnapshot.AdLanguageEnglish = $true
                     }
                 }

--- a/modules/TierModel/public/Test-TierModelPrerequisites.ps1
+++ b/modules/TierModel/public/Test-TierModelPrerequisites.ps1
@@ -383,6 +383,56 @@ function Test-TierModelPrerequisites {
             }
         }
         
+        # --- English-language Active Directory check (unconditional) ---
+        # The Tier Model references well-known principals by their English names. On a
+        # fully-localized non-English domain those names differ (set at domain creation
+        # from the DC install language and replicated), so deployments and audits would
+        # fail. Resolve three well-known groups BY SID and confirm each directory Name is
+        # its expected English value. Names are read from AD (not translated client-side,
+        # which the local OS would localize and give a false pass). Guarded so it is a
+        # no-op when AD cannot be evaluated; see docs/language-support.md for the policy.
+        if (Get-Module ActiveDirectory -ErrorAction SilentlyContinue) {
+            try {
+                $adLangDomain = Get-ADDomain -Server $PreferredDc -ErrorAction Stop
+                $domainSid = if ($adLangDomain.DomainSID) { $adLangDomain.DomainSID.Value } else { $null }
+
+                # Only evaluate with a real domain SID (S-1-5-21-...). Anything else
+                # (unresolved domain) is treated as "cannot determine" and skipped.
+                if ($domainSid -match '^S-1-5-21-') {
+                    $englishCanaries = @(
+                        [PSCustomObject]@{ Expected = 'Domain Admins';     Sid = "$domainSid-512" }
+                        [PSCustomObject]@{ Expected = 'Server Operators';  Sid = 'S-1-5-32-549' }
+                        [PSCustomObject]@{ Expected = 'Account Operators'; Sid = 'S-1-5-32-548' }
+                    )
+
+                    $languageMismatches = [System.Collections.ArrayList]@()
+                    foreach ($canary in $englishCanaries) {
+                        $grp = Get-ADGroup -Identity $canary.Sid -Server $PreferredDc -ErrorAction Stop
+                        if ($null -ne $grp -and -not [string]::IsNullOrEmpty($grp.Name) -and $grp.Name -ne $canary.Expected) {
+                            $null = $languageMismatches.Add("$($canary.Expected) is named '$($grp.Name)'")
+                        }
+                    }
+
+                    if ($languageMismatches.Count -gt 0) {
+                        $result.Valid = $false
+                        $result.EnvironmentSnapshot.AdLanguageEnglish = $false
+                        $result.EnvironmentSnapshot.AdLanguageMismatches = @($languageMismatches)
+                        $null = $result.Errors.Add("Non-English Active Directory detected. The Tier Model supports English (en-US) Active Directory only.")
+                        $null = $result.Remediation.Add("Run Deploy and Audit against an English (en-US) Active Directory. See Language Support: https://microsoft.github.io/ActiveDirectoryTierModel/language-support/")
+                    }
+                    else {
+                        $result.EnvironmentSnapshot.AdLanguageEnglish = $true
+                    }
+                }
+            }
+            catch {
+                # AD language could not be evaluated (e.g. AD Web Services unreachable).
+                # Do not hard-fail here; DC reachability and domain-admin checks already
+                # gate a broken AD connection. Record the condition for diagnostics.
+                $result.EnvironmentSnapshot.AdLanguageCheckError = $_.Exception.Message
+            }
+        }
+
         # --- MSA/gMSA/dMSA/WinLaps Prerequisites (shared schema/DFL resolution) ---
         if ($IncludeMsa -or $IncludeGmsa -or $IncludeDmsa -or $IncludeWinLaps) {
             $schemaDN = $null

--- a/tests/Integration.Module.Tests.ps1
+++ b/tests/Integration.Module.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'TierModel Module Integration Tests' -Tag 'Integration', 'Module' {
         }
         
         It 'Module version is correct' {
-            $script:LoadedModule.Version.ToString() | Should -Be '1.2.1'
+            $script:LoadedModule.Version.ToString() | Should -Be '1.2.2'
         }
         
         It 'Module loads all public function files' {

--- a/tests/Integration.WinLapsDeployment.Tests.ps1
+++ b/tests/Integration.WinLapsDeployment.Tests.ps1
@@ -58,6 +58,10 @@ Describe "Integration: Windows LAPS Deployment Pipeline" -Tag "Integration", "Wi
         # ── Baseline mocks (all resources exist, all permissions absent) ─────────
         Mock Write-TierModelLog -ModuleName TierModel { }
 
+        # Host OS install language defaults to English (en-US) so the prerequisite
+        # host-OS language gate passes and the deployment flow proceeds.
+        Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0409' }
+
         Mock Resolve-TierModelDomainDN -ModuleName TierModel { return $script:TestDomainDN }
 
         Mock Resolve-TierModelPlaceholder -ModuleName TierModel {

--- a/tests/Unit.ModuleManifest.Tests.ps1
+++ b/tests/Unit.ModuleManifest.Tests.ps1
@@ -38,8 +38,8 @@ Describe 'TierModel Module Manifest' -Tag 'Unit', 'Manifest' {
             $script:Manifest.ModuleVersion | Should -Match '^\d+\.\d+\.\d+$'
         }
         
-        It 'Has current version 1.2.1' {
-            $script:Manifest.ModuleVersion | Should -Be '1.2.1'
+        It 'Has current version 1.2.2' {
+            $script:Manifest.ModuleVersion | Should -Be '1.2.2'
         }
         
         It 'Has valid GUID' {

--- a/tests/Unit.Prerequisites.Tests.ps1
+++ b/tests/Unit.Prerequisites.Tests.ps1
@@ -256,6 +256,76 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
         }
     }
     
+    Context "AD Language Enforcement" -Tag 'Language','Prereq' {
+        BeforeAll {
+            Mock Import-Module -ModuleName TierModel { }
+            Mock Get-Module -ModuleName TierModel {
+                param($Name)
+                switch ($Name) {
+                    'ActiveDirectory' { return [PSCustomObject]@{ Name = 'ActiveDirectory'; Version = [version]'1.0.1.0' } }
+                    'GroupPolicy'     { return [PSCustomObject]@{ Name = 'GroupPolicy';     Version = [version]'1.0' } }
+                    'Pester'          { return [PSCustomObject]@{ Name = 'Pester';          Version = [version]'5.7.1' } }
+                    default           { return $null }
+                }
+            }
+            Mock Get-ADForest      -ModuleName TierModel { return [PSCustomObject]@{ RootDomain = 'test.local' } }
+            Mock Get-ADGroupMember -ModuleName TierModel { return @() }
+            Mock Get-ADDomain -ModuleName TierModel {
+                return [PSCustomObject]@{
+                    DNSRoot     = 'test.local'
+                    NetBIOSName = 'TEST'
+                    DomainSID   = [PSCustomObject]@{ Value = 'S-1-5-21-1111111111-2222222222-3333333333' }
+                }
+            }
+        }
+
+        It "fails fast with a friendly error when well-known group names are non-English (German)" -Tag 'Negative','Language' {
+            Mock Get-ADGroup -ModuleName TierModel {
+                param($Identity)
+                switch -Wildcard ("$Identity") {
+                    '*-512'        { return [PSCustomObject]@{ Name = 'Domänen-Admins';    SID = $Identity } }
+                    'S-1-5-32-549' { return [PSCustomObject]@{ Name = 'Server-Operatoren'; SID = $Identity } }
+                    'S-1-5-32-548' { return [PSCustomObject]@{ Name = 'Konten-Operatoren'; SID = $Identity } }
+                    default        { return [PSCustomObject]@{ Name = "$Identity";         SID = $Identity } }
+                }
+            }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.Valid | Should -Be $false
+            $result.EnvironmentSnapshot.AdLanguageEnglish | Should -Be $false
+            ($result.Errors -join ' ') | Should -Match 'Non-English Active Directory'
+            ($result.Remediation -join ' ') | Should -Match 'language-support'
+            ($result.EnvironmentSnapshot.AdLanguageMismatches -join ' ') | Should -Match 'Server-Operatoren'
+        }
+
+        It "passes the AD language check when all three well-known group names are English" -Tag 'Positive','Language' {
+            Mock Get-ADGroup -ModuleName TierModel {
+                param($Identity)
+                switch -Wildcard ("$Identity") {
+                    '*-512'        { return [PSCustomObject]@{ Name = 'Domain Admins';     SID = $Identity } }
+                    'S-1-5-32-549' { return [PSCustomObject]@{ Name = 'Server Operators';  SID = $Identity } }
+                    'S-1-5-32-548' { return [PSCustomObject]@{ Name = 'Account Operators'; SID = $Identity } }
+                    default        { return [PSCustomObject]@{ Name = "$Identity";         SID = $Identity } }
+                }
+            }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.EnvironmentSnapshot.AdLanguageEnglish | Should -Be $true
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English Active Directory'
+        }
+
+        It "does not fail the language check when Active Directory cannot be evaluated" -Tag 'Language' {
+            Mock Get-ADDomain -ModuleName TierModel { throw 'Domain unreachable' }
+            Mock Get-ADGroup  -ModuleName TierModel { return $null }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English Active Directory'
+        }
+    }
+
     Context "Result Object Structure" {
         It "Should return properly structured result object" -Tag 'Positive','Structure' {
             $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $validDepsFile

--- a/tests/Unit.Prerequisites.Tests.ps1
+++ b/tests/Unit.Prerequisites.Tests.ps1
@@ -372,6 +372,27 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
             ($result.Errors -join ' ') | Should -Not -Match 'Non-English Active Directory'
         }
 
+        It "still flags non-English when a later well-known group cannot be resolved" -Tag 'Negative','Language' {
+            # Domain Admins (localized) resolves first, Server Operators then throws, and
+            # Account Operators (localized) resolves last. The confirmed mismatches must not
+            # be discarded by the mid-loop failure — the gate must still fail closed.
+            Mock Get-ADGroup -ModuleName TierModel {
+                param($Identity)
+                switch -Wildcard ("$Identity") {
+                    '*-512'        { return [PSCustomObject]@{ Name = 'Domänen-Admins';    SID = $Identity } }
+                    'S-1-5-32-549' { throw 'transient AD failure' }
+                    'S-1-5-32-548' { return [PSCustomObject]@{ Name = 'Konten-Operatoren'; SID = $Identity } }
+                    default        { return [PSCustomObject]@{ Name = "$Identity";         SID = $Identity } }
+                }
+            }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.Valid | Should -Be $false
+            ($result.Errors -join ' ') | Should -Match 'Non-English Active Directory'
+            ($result.EnvironmentSnapshot.AdLanguageMismatches -join ' ') | Should -Match 'Domänen-Admins'
+        }
+
         It "does not fail the language check when Active Directory cannot be evaluated" -Tag 'Language' {
             Mock Get-ADDomain -ModuleName TierModel { throw 'Domain unreachable' }
             Mock Get-ADGroup  -ModuleName TierModel { return $null }
@@ -379,6 +400,18 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
             $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
 
             ($result.Errors -join ' ') | Should -Not -Match 'Non-English Active Directory'
+        }
+
+        It "skips the language check when the domain SID cannot be determined" -Tag 'Language' {
+            Mock Get-ADDomain -ModuleName TierModel {
+                return [PSCustomObject]@{ DNSRoot = 'test.local'; NetBIOSName = 'TEST'; DomainSID = $null }
+            }
+            Mock Get-ADGroup -ModuleName TierModel { return $null }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English Active Directory'
+            $result.EnvironmentSnapshot.ContainsKey('AdLanguageEnglish') | Should -Be $false
         }
     }
 

--- a/tests/Unit.Prerequisites.Tests.ps1
+++ b/tests/Unit.Prerequisites.Tests.ps1
@@ -13,6 +13,11 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
         # Mock external dependencies
         Mock Test-NetConnection { return $true } -ParameterFilter { $ComputerName -eq 'MockDC.test.local' } -ModuleName TierModel
         Mock Test-NetConnection { return $false } -ParameterFilter { $ComputerName -eq 'UnreachableDC.test.local' } -ModuleName TierModel
+
+        # Default the host OS language to English (en-US) so the unconditional host-OS
+        # language gate passes and execution reaches the remaining checks. Individual
+        # language tests override this per-case.
+        Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0409' }
         
         # Create test dependencies file content
         $validDependencies = @{
@@ -256,6 +261,57 @@ Describe "TierModel Prerequisites Tests" -Tag 'Unit','Prereq' {
         }
     }
     
+    Context "Host OS Language Enforcement" -Tag 'Language','Prereq' {
+        It "fails fast with a friendly error when the host OS install language is non-English (German)" -Tag 'Negative','Language' {
+            Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0407' }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.Valid | Should -Be $false
+            $result.EnvironmentSnapshot.HostOsEnglish | Should -Be $false
+            ($result.Errors -join ' ') | Should -Match 'Non-English host operating system'
+            ($result.Remediation -join ' ') | Should -Match 'language-support'
+        }
+
+        It "stops before the Pester/module checks on a non-English host OS (early return)" -Tag 'Negative','Language' {
+            Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0407' }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            # Early return means later checks never ran: their snapshot keys are absent
+            # and no Pester/module remediation is surfaced on an unsupported OS.
+            $result.EnvironmentSnapshot.ContainsKey('PesterVersion') | Should -Be $false
+            ($result.Errors -join ' ') | Should -Not -Match 'Pester'
+        }
+
+        It "passes the host OS check when the install language is English (en-US, 0409)" -Tag 'Positive','Language' {
+            Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0409' }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.EnvironmentSnapshot.HostOsEnglish | Should -Be $true
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English host operating system'
+        }
+
+        It "accepts other English variants such as en-GB (0809)" -Tag 'Positive','Language' {
+            Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { return '0809' }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            $result.EnvironmentSnapshot.HostOsEnglish | Should -Be $true
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English host operating system'
+        }
+
+        It "does not hard-fail on the OS check when the install language cannot be read" -Tag 'Language' {
+            Mock Get-ItemPropertyValue -ModuleName TierModel -ParameterFilter { $Name -eq 'InstallLanguage' } { throw 'registry value not found' }
+
+            $result = Test-TierModelPrerequisites -PreferredDc 'MockDC.test.local' -DependenciesPath $script:validDepsFile
+
+            ($result.Errors -join ' ') | Should -Not -Match 'Non-English host operating system'
+            $result.EnvironmentSnapshot.HostOsLanguageCheckError | Should -Not -BeNullOrEmpty
+        }
+    }
+
     Context "AD Language Enforcement" -Tag 'Language','Prereq' {
         BeforeAll {
             Mock Import-Module -ModuleName TierModel { }
@@ -957,6 +1013,8 @@ Describe "Test-TierModelPrerequisites – Extended Coverage" -Tag "Unit", "Prere
             Mock Test-NetConnection   { return $true }
             Mock Write-TierModelLog   { }
             Mock Import-Module        { }
+            # Host OS install language defaults to English (en-US) so the OS gate passes
+            Mock Get-ItemPropertyValue { return '0409' } -ParameterFilter { $Name -eq 'InstallLanguage' }
             # Pester present at the right version
             Mock Get-Module { return [PSCustomObject]@{ Name = 'Pester'; Version = [version]'5.7.1' } } `
                 -ParameterFilter { $ListAvailable -eq $true -and $Name -eq 'Pester' }


### PR DESCRIPTION
## Linked issue

Closes #23

## What this PR does

Adds **English-language enforcement** so the Tier Model fails fast — before any deployment or audit change — when the environment is not English (`en-US`). This is the documentation + guard-rail direction agreed on issue #23 (the alternative, full language-independent SID resolution in PR #18, is intentionally **not** taken here).

Two unconditional checks are added to `Test-TierModelPrerequisites` and are inherited by both `Deploy-TierModel.ps1` and `Audit-TierModel.ps1`:

1. **Host operating system** — reads the local machine's static `InstallLanguage` LCID (`HKLM\SYSTEM\CurrentControlSet\Control\Nls\Language`) and requires an English variant (primary language `0x09`, e.g. en-US/en-GB). Runs after the elevation check and **before** the Pester/module checks, and returns immediately on a non-English host so the operator is never asked to install modules on an unsupported OS.
2. **Active Directory** — resolves three well-known groups **by SID** (Domain Admins `<DomainSID>-512`, Server Operators `S-1-5-32-549`, Account Operators `S-1-5-32-548`) and requires each directory `Name` to be its English value. Child-domain safe (no Enterprise/Schema Admins); names are read from AD (never client-side SID translation, which the local OS would localize into a false pass). Fails closed even if one well-known group cannot be resolved mid-check.

Also included: new `docs/language-support.md` (English-only rationale, the 18 fully-localized Windows Server languages that are detected/stopped, and a future community-localization roadmap), prerequisite notes across README + deployment guides + FAQ, `CHANGELOG` entry, and the **v1.2.2** version bump.

## Security / tiering impact

- **Touches prerequisites** — adds two new fail-fast validations. It **tightens** (never relaxes) validation: a non-English environment is now stopped up front instead of proceeding to partial/failed deployments where localized well-known-group names don't resolve.
- **No changes** to OUs, ACLs/delegations, GPOs, tier boundaries, or the security topology. No new public parameters or alternate topologies are introduced.
- English (`en-US`) deployments and audits are behaviorally **unchanged** (verified on a live English DC — see testing).

## Testing

- **Automated:** `.\tests\Invoke-AllTests.ps1` — **1,435 / 1,435 passing**, overall docs-scope coverage **88.72%** (module scope ~91%, all above the 80% CI gate). New prerequisite code is fully covered (10 new unit tests).
- **Lint:** PSScriptAnalyzer (CI ruleset) — **0 issues** on the module.
- **Live English lab (Windows Server 2025, `en-US`):** `-FullDeployment` with `-IncludeMsa -IncludeGmsa -IncludeDmsa -IncludeWinLaps` → **Applied 705, Errors 0**; full audit (all features) → **100% compliant, 0 drift, 0 errors**. Both logged "Prerequisites validation passed" (the new checks are transparent to a genuine English environment).
- **Live German lab:** the host-OS check correctly **fails fast** with the friendly non-English message before any change.

## Checklist

- [x] This change was **discussed and agreed in the linked issue before I wrote code**
- [x] The PR addresses **one concern** (English-language enforcement + its release)
- [x] I did **not** add new public parameters, alternate topologies, or relax prerequisite / validation logic unless it was the agreed subject of the issue
- [x] Tests added or updated; `.\tests\Invoke-AllTests.ps1` passes and coverage stays **≥ 80%**
- [x] No unrelated reformatting or whitespace churn
- [x] Documentation updated for any changed behavior
