### PR TITLE
security: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Install PowerShell Modules
       shell: pwsh
@@ -83,7 +83,7 @@ jobs:
         }
         
     - name: Upload ScriptAnalyzer Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: scriptanalyzer-results
@@ -98,7 +98,7 @@ jobs:
         
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Install Dependencies
       shell: pwsh
@@ -176,7 +176,7 @@ jobs:
         }
         
     - name: Upload Test Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: test-results
@@ -193,7 +193,7 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Validate Module Structure
       shell: pwsh
@@ -261,7 +261,7 @@ jobs:
         Get-ChildItem $packagePath | Format-Table Name, Length -AutoSize
         
     - name: Upload Module Package
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: TierModel-Module
         path: TierModel-Package/
@@ -275,7 +275,7 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Install Security Tools
       shell: pwsh
@@ -309,7 +309,7 @@ jobs:
         }
         
     - name: Upload Security Results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: security-analysis
@@ -329,10 +329,10 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.x'
         
@@ -343,13 +343,13 @@ jobs:
       run: mkdocs build --strict
       
     - name: Upload Pages Artifact
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: site/
         
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   # Job 8: Create GitHub Release
   release:
@@ -360,7 +360,7 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       
     - name: Create Release ZIP
       shell: pwsh
@@ -398,7 +398,7 @@ jobs:
         Write-Host "version=$version" >> $env:GITHUB_OUTPUT
         
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
       with:
         name: ${{ github.ref_name }}
         generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   union-merge rules were dropped from `.gitattributes`, and the `specs/**` documents
   that pointed into `.squad/` now reference the specs themselves instead.
 
+### Security
+- Pinned every GitHub Action used by the CI workflow to a full-length commit SHA,
+  with the human-readable version retained in a trailing comment. Mutable tags such
+  as `@v4` can be repointed at malicious code if a maintainer account or release
+  process is compromised; a commit SHA cannot. No workflow behavior changed — only
+  action resolution became immutable. Contributed by Dan Fiedler.
+- Added `.github/dependabot.yml` so Dependabot tracks the `github-actions` ecosystem
+  and proposes SHA updates as maintainers publish new versions, after a 7-day
+  cooldown. This keeps the pinned references maintainable.
+
 ## [2.1.0] - 2026-09-08
 
 ### Added


### PR DESCRIPTION
Re-lands #53 from a branch in this repository so it can actually merge.

**Credit:** the pinning commit is authored by **Dan Fiedler** (`danfiedler@microsoft.com`) and is cherry-picked unchanged from #53. Only a CHANGELOG entry was added on top.

## Why this PR exists instead of merging #53

#53 came from a fork, and it can never merge here:

- The `Main Branch Protection` ruleset has a `code_scanning` rule requiring a **CodeQL** analysis.
- CodeQL is configured with **default setup**, which does not run for pull requests from external forks. No analysis is ever produced for a fork PR's head SHA. (Tracking issue: github/codeql-action#2136)
- The ruleset treats a missing analysis as still pending and blocks the merge indefinitely. The ruleset has **no bypass actors**, so admin rights do not override it.

All four required status checks pass on #53; the block is solely the missing CodeQL analysis. Updating or rebasing #53 would not help.

## What changed

- `.github/workflows/ci.yml` — every action pinned to a full-length commit SHA, version retained in a trailing comment.
- `.github/dependabot.yml` — new; tracks the `github-actions` ecosystem with a 7-day cooldown so pins stay maintainable.

No workflow behavior changes. Only action resolution becomes immutable.

## SHA verification

Each pinned SHA was checked against the tag it replaces via `GET /repos/{owner}/{repo}/commits/{tag}`:

| Action | Version | Pinned SHA | Verified |
|---|---|---|---|
| `actions/checkout` | v6.1.0 | `d23441a48e...` | match |
| `actions/deploy-pages` | v5.0.1 | `368f825286...` | match |
| `actions/setup-python` | v6.3.0 | `ece7cb06ca...` | match |
| `actions/upload-artifact` | v7.0.1 | `043fb46d1a...` | match |
| `actions/upload-pages-artifact` | v5.0.0 | `fc324d3547...` | match |
| `softprops/action-gh-release` | v3.0.3 | `efb35369e0...` | match |

`ci.yml` is the only workflow tracked in this repository, and it contains no actions referenced by branch name, so the repository is fully compliant with the commit-SHA pinning requirement after this merge.

Replaces #53 (closing keywords do not auto-close pull requests, so #53 will be closed manually once this merges).

