### PR TITLE
docs: correct coverage figures to CI's measured values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and proposes SHA updates as maintainers publish new versions, after a 7-day
   cooldown. This keeps the pinned references maintainable.
 
+### Documentation
+- Corrected the automated coverage figures in `README.md` and `docs/test-coverage.md`
+  to the values CI actually measured: **87.63%** across the CI-scoped 82-file module
+  population (14,651 of 16,719 commands), replacing a stale 87.36% / 14,606. Test
+  counts and the manual UAT figures are unchanged.
+
 ## [2.1.0] - 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ To get started with TierModel, please refer to our comprehensive documentation:
 
 | Test Suite | Test Files | Test Cases | Status | Coverage |
 |------------|-----------|------------|--------|----------|
-| **Unit Tests** | **26 files** (Pester) | **1,664 tests** | ✅ All pass | **87.36%** *(CI-scoped 82-file module population)* |
-| **Integration Tests** | **7 files** (Pester) | **330 tests** | ✅ All pass | **87.36%** *(CI-scoped 82-file module population)* |
+| **Unit Tests** | **26 files** (Pester) | **1,664 tests** | ✅ All pass | **87.63%** *(CI-scoped 82-file module population)* |
+| **Integration Tests** | **7 files** (Pester) | **330 tests** | ✅ All pass | **87.63%** *(CI-scoped 82-file module population)* |
 | **Manual Integration Tests** | **1 file** (Excel workbook) | **384 tests** | ✅ 100% Pass | **N/A** |
-| **Total** | **34 files** | **2,378 tests** | ✅ **100% passing** | **87.36%** *(CI-scoped 82-file module population)* |
+| **Total** | **34 files** | **2,378 tests** | ✅ **100% passing** | **87.63%** *(CI-scoped 82-file module population)* |
 
 ### Test Coverage Highlights
 - ✅ **86/86** production PowerShell files in the product surface counted: 2 root `*-TierModel.ps1`, 82 under `modules\`, and 2 under `optional\`; CI coverage measures the CI-scoped 82-file module population
 - ✅ **1,994 / 1,994** automated test cases passing — 0 failures (Pester 5.9.0, 2026-09-08)
-- ✅ **87.36%** overall Pester-measured command coverage across the CI-scoped 82-file module population (aggregate clears the 80% CI gate; the gate is not per-file)
+- ✅ **87.63%** overall Pester-measured command coverage across the CI-scoped 82-file module population (aggregate clears the 80% CI gate; the gate is not per-file)
 
 ### Running Tests
 ```powershell

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -9,9 +9,9 @@
 
 > **How coverage is measured:** Pester v5's built-in `CodeCoverage` feature instruments the CI-scoped 82-file module population and tracks which commands are executed during the full test suite run (`Invoke-AllTests.ps1`). To re-run: `cd TierModel; $c = New-PesterConfiguration; $c.Run.Path = '.\tests'; $c.CodeCoverage.Enabled = $true; $c.CodeCoverage.Path = @('.\modules\TierModel\*.psm1','.\modules\TierModel\public\*.ps1','.\optional\Update-TierModelMembership.ps1'); Invoke-Pester -Configuration $c`
 
-**Last measured:** 2026-09-08 (1,994 automated tests: **1,994 passing / 0 failures — 100%** — Pester 5.9.0 pinned) | **Overall: 87.36%** *(CI-scoped 82-file module population; 14,606/16,719 commands executed)* | **Target: 95%** | **CI gate: 80% aggregate**
+**Last measured:** 2026-09-08 (1,994 automated tests: **1,994 passing / 0 failures — 100%** — Pester 5.9.0 pinned) | **Overall: 87.63%** *(CI-scoped 82-file module population; 14,651/16,719 commands executed)* | **Target: 95%** | **CI gate: 80% aggregate**
 
-> ✅ **Debug-forwarding prohibition guard measured (2026-09-08 — 100% pass rate):** `tests/Unit.DebugProhibition.Tests.ps1` adds **6** static AST tests for FR-017. It fails the build if any Active Directory or GroupPolicy invocation carries literal `-Debug` or splats `@PSBoundParameters`, which can forward `-Debug` invisibly. This improves safety, not coverage: the guard parses files but does not execute instrumented module commands, so coverage remains **87.36%** over the same CI-scoped 82-file module population.
+> ✅ **Debug-forwarding prohibition guard measured (2026-09-08 — 100% pass rate):** `tests/Unit.DebugProhibition.Tests.ps1` adds **6** static AST tests for FR-017. It fails the build if any Active Directory or GroupPolicy invocation carries literal `-Debug` or splats `@PSBoundParameters`, which can forward `-Debug` invisibly. This improves safety, not coverage: the guard parses files but does not execute instrumented module commands, so coverage remains **87.63%** over the same CI-scoped 82-file module population.
 
 > ✅ **Membership Reconciliation script measured (2026-09-07 — 100% pass rate):** `optional/Update-TierModelMembership.ps1` (v1.7.2, standalone scheduled-task script) added to CI code-coverage measurement and covered by new `Unit.MembershipReconciliation.Tests.ps1` (**107 tests**, dot-source seam, all mock-based). Functions covered: `Resolve-ActiveSwitches`, `Test-IsBuiltInExcluded`, `Test-IsCustomerExcluded`, `Initialize-BuiltInExclusions`, `Write-TmEvent`, `Initialize-Logging`, `Write-Log`, `Write-DebugLog`, `Resolve-OuDn`, `Resolve-GroupSam`, `Invoke-TierReconciliation`, `Invoke-Tier2Operators`, `Invoke-Tier2Eud`. NOT unit-tested (inline in main try-block, integration-covered by Joel lab UAT): exclusion parameter-pairing gate, `-NoExclusions` safety gate, `Invoke-Tier0/1/2*` dispatch wrappers, `Invoke-BuiltInExclusionEnforcement`. Script coverage measured **60.18%** (top-level standalone script; inline main-block and dispatch wrappers not reachable via dot-source). Overall aggregate 1,783 -> **1,980 automated tests** (+107 membership; +1 merged #48 prerequisite test; +89 other new tests in v2.1.0). 71 -> **72** production files measured.
 
@@ -123,7 +123,7 @@
 | `modules/TierModel/public/Format-TierModelDuration.ps1` | 11 | 0 | 11 | ✅ 100% |
 | `modules/TierModel/public/Build-TierModelAuthSddl.ps1` | 5 | 0 | 5 | ✅ 100% |
 | `modules/TierModel/public/New-TierModelAuthSilo.ps1` | 108 | 1 | 109 | 🟡 99.1% |
-| **TOTAL (CI-scoped 82-file module population)** | 14,606 | 2,113 | 16,719 | **87.36%** |
+| **TOTAL (CI-scoped 82-file module population)** | 14,651 | 2,113 | 16,719 | **87.63%** |
 
 > **✦** = File has a documented structural barrier preventing full coverage without production code refactoring. See **Hard Coverage Limits** table below for details.
 
@@ -231,7 +231,7 @@
 | `Audit-TierModel.ps1` | 873 | 318 | 1191 | 🔴 73.3% |
 | `Deploy-TierModel.ps1` | 1871 | 638 | 2509 | 🔴 74.6% |
 
-> **Note:** Both `Audit-TierModel.ps1` and `Deploy-TierModel.ps1` are top-level orchestrator scripts (not under `modules/TierModel/*`) and are exempt from the module-scope 80% CI gate. Both grew in total line count with every feature addition (BUG fixes, canonical-ACL, audit-rule, auth-silo), shrinking the percentage even as covered lines increased. `Audit-TierModel.ps1` has ByServer live-LDAP paths (`Invoke-CanonicalAclAudit` ByServer-mode) exempt per team ruling; the CI-scoped 82-file module population aggregate remains **87.36%** and clears the 80% gate.
+> **Note:** Both `Audit-TierModel.ps1` and `Deploy-TierModel.ps1` are top-level orchestrator scripts (not under `modules/TierModel/*`) and are exempt from the module-scope 80% CI gate. Both grew in total line count with every feature addition (BUG fixes, canonical-ACL, audit-rule, auth-silo), shrinking the percentage even as covered lines increased. `Audit-TierModel.ps1` has ByServer live-LDAP paths (`Invoke-CanonicalAclAudit` ByServer-mode) exempt per team ruling; the CI-scoped 82-file module population aggregate remains **87.63%** and clears the 80% gate.
 
 ### 🚨 Critical Gaps: <25% Coverage (0 files)
 


### PR DESCRIPTION
Ports a commit that was stranded on `feature/enable-verbose-debug`.

`f57b322` ("Correct coverage figures to CI's measured values") was committed on 2026-09-08 at 18:26 **after** #52 had already been squash-merged, so it never reached `main`. Squash merging rewrites SHAs, which is why the branch still looked unmerged while its earlier content was in fact all present.

## What changes

Only the automated coverage figures in `README.md` and `docs/test-coverage.md`:

| | `main` before | corrected |
|---|---|---|
| Overall coverage | 87.36% | **87.63%** |
| Commands executed | 14,606 | **14,651** |

Total commands (16,719), all test counts, and the manual UAT figures are unchanged. Documentation only — no code, no tests, no workflow changes.

Once this merges, `feature/enable-verbose-debug` holds nothing that is not on `main` and can be deleted.
